### PR TITLE
organização de pastas

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 | `lib/ciphers/` | Implementações puras das cifras |
 | `types/` | Tipos compartilhados (ex.: `cipher.ts`) |
 
-Imports com alias `@/` apontam para a raiz do repositório (`tsconfig.json` → `paths`: `"@/*": ["./*"]`).
+Imports com alias `@/` apontam para a raiz do repositório (`tsconfig.json` → `paths`: `"@/*": ["./*"]`). Exemplo:
+
+```ts
+import { PlaceholderNotice } from "@/components/PlaceholderNotice"
+```
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Estrutura do código
+
+| Pasta | Uso |
+|--------|-----|
+| `app/` | Rotas App Router |
+| `components/` | UI reutilizável |
+| `lib/ciphers/` | Implementações puras das cifras |
+| `types/` | Tipos compartilhados (ex.: `cipher.ts`) |
+
+Imports com alias `@/` apontam para a raiz do repositório (`tsconfig.json` → `paths`: `"@/*": ["./*"]`).
+
 ## Getting Started
 
 First, run the development server:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,14 @@
 import Image from "next/image";
+import { PlaceholderNotice } from "@/components/PlaceholderNotice";
 
 export default function Home() {
   return (
     <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
+        <PlaceholderNotice
+          title="Estrutura base: app/, components/, lib/ciphers/, types/."
+          sampleCipher={{ id: "placeholder", label: "CV-003" }}
+        />
         <Image
           className="dark:invert"
           src="/next.svg"

--- a/components/PlaceholderNotice.test.tsx
+++ b/components/PlaceholderNotice.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { PlaceholderNotice } from "./PlaceholderNotice";
+
+describe("PlaceholderNotice", () => {
+  it("renderiza o título", () => {
+    render(<PlaceholderNotice title="Em breve" />);
+    expect(screen.getByText("Em breve")).toBeInTheDocument();
+  });
+
+  it("mostra metadados quando sampleCipher é passado", () => {
+    render(
+      <PlaceholderNotice
+        title="Cifra"
+        sampleCipher={{ id: "demo", label: "Demonstração" }}
+      />,
+    );
+    expect(screen.getByText(/Demonstração/)).toBeInTheDocument();
+    expect(screen.getByText(/demo/)).toBeInTheDocument();
+  });
+});

--- a/components/PlaceholderNotice.tsx
+++ b/components/PlaceholderNotice.tsx
@@ -1,0 +1,27 @@
+import type { CipherMetadata } from "@/types/cipher";
+
+type PlaceholderNoticeProps = {
+  /** Texto curto para smoke test de imports `@/components`. */
+  title: string;
+  /** Opcional: amarra `types/cipher` ao UI até as cifras existirem. */
+  sampleCipher?: CipherMetadata;
+};
+
+export function PlaceholderNotice({
+  title,
+  sampleCipher,
+}: PlaceholderNoticeProps) {
+  return (
+    <p className="max-w-md text-sm text-zinc-500 dark:text-zinc-500">
+      {title}
+      {sampleCipher ? (
+        <>
+          {" "}
+          <span className="font-mono text-zinc-600 dark:text-zinc-400">
+            ({sampleCipher.label} · {sampleCipher.id})
+          </span>
+        </>
+      ) : null}
+    </p>
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,13 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // next/jest em CJS: require() é esperado aqui.
+  {
+    files: ["jest.config.js", "jest.config.cjs"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+const nextJest = require("next/jest");
+
+const createJestConfig = nextJest({ dir: "./" });
+
+/** @type {import("jest").Config} */
+const customJestConfig = {
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  testEnvironment: "jest-environment-jsdom",
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/lib/placeholder.test.ts
+++ b/lib/placeholder.test.ts
@@ -1,0 +1,7 @@
+import { placeholderEcho } from "./placeholder";
+
+describe("placeholder (lib)", () => {
+  it("ecoa o valor", () => {
+    expect(placeholderEcho("ping")).toBe("ping");
+  });
+});

--- a/lib/placeholder.ts
+++ b/lib/placeholder.ts
@@ -1,0 +1,5 @@
+/** Placeholder de lógica pura em TS até módulos reais (ex.: cifras). */
+
+export function placeholderEcho(value: string): string {
+  return value;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "next": "16.2.4",
@@ -15,11 +17,17 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/types/cipher.ts
+++ b/types/cipher.ts
@@ -4,7 +4,7 @@
  */
 export type CipherId = string;
 
-export interface CipherMetadata {
+export type CipherMetadata = {
   id: CipherId;
   label: string;
-}
+};

--- a/types/cipher.ts
+++ b/types/cipher.ts
@@ -1,0 +1,10 @@
+/**
+ * Tipos de cifra — placeholder até CV-004.
+ * Evite lógica aqui; apenas contratos compartilhados.
+ */
+export type CipherId = string;
+
+export interface CipherMetadata {
+  id: CipherId;
+  label: string;
+}


### PR DESCRIPTION
# Pull request: CV-003 — Estrutura de pastas do repositório

## Resumo

Implementa a issue **CV-003** (fundação do layout de código): pastas acordadas para o App Router, UI partilhada, cifras em `lib/` e tipos em `types/`, com ficheiros mínimos para versionar diretórios vazios e um import real na app que valida o alias `@/`.

## Contexto

- **Épico:** E1 — Fundação  
- **Objetivo:** evitar refactors grandes quando entram CV-004/CV-005 e fixar um único sítio para imports (`@/…`).

## Alterações

### Pastas e ficheiros novos

| Caminho | Descrição |
|---------|-----------|
| `components/PlaceholderNotice.tsx` | Componente de exemplo; importa tipos de `@/types/cipher` para amarrar `components/` a `types/`. |
| `lib/ciphers/.gitkeep` | Garante que `lib/ciphers/` existe no Git até haver implementações puras das cifras. |
| `types/cipher.ts` | Placeholder de tipos (`CipherId`, `CipherMetadata`) até CV-004. |

### Ficheiros modificados

- **`app/page.tsx`** — passa a importar e renderizar `PlaceholderNotice` de `@/components/PlaceholderNotice`, cumprindo o critério de “pelo menos um import na app”.
- **`README.md`** — secção **Estrutura do código** com tabela das pastas e nota sobre o alias `@/` (`paths` em `tsconfig.json`).

### Configuração TypeScript

- Mantém-se **`"paths": { "@/*": ["./*"] }`** em `tsconfig.json` (sem `baseUrl`, alinhado ao TypeScript 6+ e à evitação do aviso de depreciação de `baseUrl`).

## Definition of Done (issue)

- [x] Pastas criadas e usadas por import na app (`components/`).
- [x] Estrutura alinhada ao plano (`app/`, `components/`, `lib/ciphers/`, `types/`), sem paths concorrentes não decididos.

## Como rever

1. `npm run lint` e `npm run build`.
2. `npm run dev` — página inicial deve mostrar o texto do aviso de estrutura (bloco do `PlaceholderNotice`).

## Notas para merge

- O conteúdo de `types/cipher.ts` e de `PlaceholderNotice` é intencionalmente mínimo; substituição/evolução em CV-004+.
- `lib/ciphers/` fica preparado para ficheiros de cifra; remover `.gitkeep` quando o primeiro `.ts` real for adicionado (opcional).
