### PR TITLE
feat(cipher): CipherDefinition, parâmetros e erros de validação (CV-004)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
       <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
         <PlaceholderNotice
           title="Estrutura base: app/, components/, lib/ciphers/, types/."
-          sampleCipher={{ id: "placeholder", label: "CV-003" }}
+          sampleCipher={{ id: "placeholder", name: "CV-004" }}
         />
         <Image
           className="dark:invert"

--- a/components/PlaceholderNotice.test.tsx
+++ b/components/PlaceholderNotice.test.tsx
@@ -11,7 +11,7 @@ describe("PlaceholderNotice", () => {
     render(
       <PlaceholderNotice
         title="Cifra"
-        sampleCipher={{ id: "demo", label: "Demonstração" }}
+        sampleCipher={{ id: "demo", name: "Demonstração" }}
       />,
     );
     expect(screen.getByText(/Demonstração/)).toBeInTheDocument();

--- a/components/PlaceholderNotice.tsx
+++ b/components/PlaceholderNotice.tsx
@@ -3,7 +3,7 @@ import type { CipherMetadata } from "@/types/cipher";
 type PlaceholderNoticeProps = {
   /** Texto curto para smoke test de imports `@/components`. */
   title: string;
-  /** Opcional: amarra `types/cipher` ao UI até as cifras existirem. */
+  /** Opcional: amarra `types/cipher` ao UI até o registry existir. */
   sampleCipher?: CipherMetadata;
 };
 
@@ -18,7 +18,7 @@ export function PlaceholderNotice({
         <>
           {" "}
           <span className="font-mono text-zinc-600 dark:text-zinc-400">
-            ({sampleCipher.label} · {sampleCipher.id})
+            ({sampleCipher.name} · {sampleCipher.id})
           </span>
         </>
       ) : null}

--- a/lib/ciphers/caesar.test.ts
+++ b/lib/ciphers/caesar.test.ts
@@ -1,0 +1,34 @@
+import { CipherValidationError } from "@/types/cipher";
+import { caesarCipher, parseCaesarParams } from "./caesar";
+
+describe("parseCaesarParams", () => {
+  it("aceita objeto com shift inteiro", () => {
+    expect(parseCaesarParams({ shift: 3 })).toEqual({ shift: 3 });
+  });
+
+  it("rejeita não-objeto", () => {
+    expect(() => parseCaesarParams(null)).toThrow(CipherValidationError);
+  });
+
+  it("rejeita shift ausente", () => {
+    expect(() => parseCaesarParams({})).toThrow(CipherValidationError);
+  });
+
+  it("rejeita shift não inteiro", () => {
+    expect(() => parseCaesarParams({ shift: 1.5 })).toThrow(CipherValidationError);
+  });
+});
+
+describe("caesarCipher", () => {
+  it("roundtrip em letras ASCII", () => {
+    const params = { shift: 3 };
+    const plain = "AbC z!";
+    const enc = caesarCipher.encode(plain, params);
+    expect(enc).toBe("DeF c!");
+    expect(caesarCipher.decode(enc, params)).toBe(plain);
+  });
+
+  it("parseParams está disponível na definição", () => {
+    expect(caesarCipher.parseParams).toBe(parseCaesarParams);
+  });
+});

--- a/lib/ciphers/caesar.ts
+++ b/lib/ciphers/caesar.ts
@@ -1,0 +1,84 @@
+import { CipherValidationError, type CipherDefinition } from "@/types/cipher";
+
+export type CaesarParams = {
+  readonly shift: number;
+};
+
+const ALPHABET_SIZE = 26;
+
+function shiftLetter(code: number, base: number, shift: number): number {
+  const i = code - base;
+  const j = (i + shift) % ALPHABET_SIZE;
+  return base + (j < 0 ? j + ALPHABET_SIZE : j);
+}
+
+function transform(text: string, shift: number, decrypt: boolean): string {
+  const delta = decrypt ? -shift : shift;
+  let out = "";
+  for (const ch of text) {
+    const code = ch.codePointAt(0);
+    if (code === undefined) {
+      out += ch;
+      continue;
+    }
+    if (ch.length === 1 && code >= 65 && code <= 90) {
+      out += String.fromCodePoint(shiftLetter(code, 65, delta));
+      continue;
+    }
+    if (ch.length === 1 && code >= 97 && code <= 122) {
+      out += String.fromCodePoint(shiftLetter(code, 97, delta));
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+export function parseCaesarParams(raw: unknown): CaesarParams {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new CipherValidationError("Parameters must be a plain object.", {
+      code: "PARAMS_OBJECT",
+      field: "*",
+    });
+  }
+  const rec = raw as Record<string, unknown>;
+  if (!("shift" in rec)) {
+    throw new CipherValidationError('Missing required field "shift".', {
+      code: "PARAM_MISSING",
+      field: "shift",
+    });
+  }
+  const shift = rec.shift;
+  if (typeof shift !== "number" || !Number.isFinite(shift)) {
+    throw new CipherValidationError('"shift" must be a finite number.', {
+      code: "PARAM_TYPE",
+      field: "shift",
+    });
+  }
+  if (!Number.isInteger(shift)) {
+    throw new CipherValidationError('"shift" must be an integer.', {
+      code: "PARAM_INTEGER",
+      field: "shift",
+    });
+  }
+  return { shift };
+}
+
+/** César apenas sobre A–Z / a–z; demais code points são preservados. */
+export const caesarCipher: CipherDefinition<CaesarParams> = {
+  id: "caesar",
+  name: "Caesar",
+  paramFields: [
+    {
+      kind: "number",
+      key: "shift",
+      label: "Shift",
+      description: "Integer rotation for Latin letters A–Z and a–z.",
+      required: true,
+      integer: true,
+    },
+  ],
+  encode: (plainText, params) => transform(plainText, params.shift, false),
+  decode: (cipherText, params) => transform(cipherText, params.shift, true),
+  parseParams: parseCaesarParams,
+};

--- a/lib/ciphers/identity.test.ts
+++ b/lib/ciphers/identity.test.ts
@@ -1,0 +1,15 @@
+import { identityCipher } from "./identity";
+
+describe("identityCipher", () => {
+  it("preserva texto com params void", () => {
+    const t = "hello";
+    expect(identityCipher.encode(t, undefined)).toBe(t);
+    expect(identityCipher.decode(t, undefined)).toBe(t);
+  });
+
+  it("expõe metadados mínimos", () => {
+    expect(identityCipher.id).toBe("identity");
+    expect(identityCipher.name).toBe("Identity");
+    expect(identityCipher.paramFields).toEqual([]);
+  });
+});

--- a/lib/ciphers/identity.ts
+++ b/lib/ciphers/identity.ts
@@ -1,0 +1,16 @@
+import type { CipherDefinition, EmptyCipherParams } from "@/types/cipher";
+
+/** Cifra identidade: útil para testes de registry e smoke de imports `lib/ciphers/*`. */
+export const identityCipher: CipherDefinition<EmptyCipherParams> = {
+  id: "identity",
+  name: "Identity",
+  paramFields: [],
+  encode: (plainText, params) => {
+    void params;
+    return plainText;
+  },
+  decode: (cipherText, params) => {
+    void params;
+    return cipherText;
+  },
+};

--- a/lib/ciphers/index.ts
+++ b/lib/ciphers/index.ts
@@ -1,0 +1,2 @@
+export { caesarCipher, parseCaesarParams, type CaesarParams } from "./caesar";
+export { identityCipher } from "./identity";

--- a/types/cipher.test.ts
+++ b/types/cipher.test.ts
@@ -1,0 +1,23 @@
+import {
+  CipherValidationError,
+  isCipherValidationError,
+} from "./cipher";
+
+describe("CipherValidationError", () => {
+  it("expõe code e field opcional", () => {
+    const err = new CipherValidationError("bad", {
+      code: "TEST",
+      field: "shift",
+    });
+    expect(err.message).toBe("bad");
+    expect(err.code).toBe("TEST");
+    expect(err.field).toBe("shift");
+    expect(err.name).toBe("CipherValidationError");
+  });
+
+  it("isCipherValidationError identifica instância", () => {
+    expect(isCipherValidationError(new CipherValidationError("x"))).toBe(true);
+    expect(isCipherValidationError(new Error("x"))).toBe(false);
+    expect(isCipherValidationError("x")).toBe(false);
+  });
+});

--- a/types/cipher.ts
+++ b/types/cipher.ts
@@ -1,10 +1,111 @@
 /**
- * Tipos de cifra — placeholder até CV-004.
- * Evite lógica aqui; apenas contratos compartilhados.
+ * Contratos compartilhados de cifras (CV-004).
+ *
+ * ## CipherDefinition<P>
+ * Cada cifra expõe um objeto de definição com:
+ * - `id`: slug estável (registry, URLs).
+ * - `name`: rótulo curto para UI.
+ * - `paramFields`: descrição **em runtime** dos campos de parâmetro para formulário
+ *   dinâmico (CV-013). Deve refletir o tipo `P` (ex.: campo `shift` quando
+ *   `P` é `{ shift: number }`). Cifras sem parâmetros usam array vazio.
+ * - `encode(plainText, params)` / `decode(cipherText, params)`: funções puras;
+ *   o mesmo `params` é usado nos dois sentidos.
+ *
+ * Validação de entradas cruas (JSON de formulário, query string) deve falhar de
+ * forma previsível: preferencialmente lançando {@link CipherValidationError}, ou
+ * retornando {@link CipherParamsParseResult} quando optar por fluxo sem exceções.
+ *
+ * Tipos de parâmetro distintos (ex.: número para César, string para Vigenère)
+ * ficam explícitos no genérico `P` e nos `paramFields` correspondentes.
  */
+
 export type CipherId = string;
 
+/** Cifra sem parâmetros configuráveis (omitir o segundo argumento nas chamadas). */
+export type EmptyCipherParams = void;
+
+/** Metadados mínimos para listas / placeholders de UI. */
 export type CipherMetadata = {
-  id: CipherId;
-  label: string;
+  readonly id: CipherId;
+  readonly name: string;
+};
+
+/** Exemplo de `P` para cifras com chave alfabética (ex.: Vigenère). */
+export type KeyStringCipherParams = {
+  readonly key: string;
+};
+
+// --- Descritores de parâmetro (formulário dinâmico) ---
+
+type CipherParamFieldBase = {
+  readonly key: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly required?: boolean;
+};
+
+export type CipherParamFieldNumber = CipherParamFieldBase & {
+  readonly kind: "number";
+  readonly min?: number;
+  readonly max?: number;
+  /** Se true (default em UI), só inteiros são aceitos na validação. */
+  readonly integer?: boolean;
+};
+
+export type CipherParamFieldString = CipherParamFieldBase & {
+  readonly kind: "string";
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  /** Regex opcional como dica de formato para UI (validar também no parse). */
+  readonly pattern?: string;
+};
+
+export type CipherParamField = CipherParamFieldNumber | CipherParamFieldString;
+
+// --- Erros de validação previsíveis ---
+
+export type CipherValidationErrorOptions = {
+  readonly code?: string;
+  readonly field?: string;
+  readonly cause?: unknown;
+};
+
+/**
+ * Erro lançado quando parâmetros ou texto de entrada violam regras da cifra.
+ * `code` estabiliza tratamento por chamadores; `field` alinha com `CipherParamField.key` quando aplicável.
+ */
+export class CipherValidationError extends Error {
+  readonly code: string;
+  readonly field?: string;
+
+  constructor(message: string, options?: CipherValidationErrorOptions) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = "CipherValidationError";
+    this.code = options?.code ?? "CIPHER_VALIDATION";
+    this.field = options?.field;
+  }
+}
+
+export function isCipherValidationError(value: unknown): value is CipherValidationError {
+  return value instanceof CipherValidationError;
+}
+
+/** Alternativa ao `throw` para parsers de parâmetros (mesmo contrato de erro). */
+export type CipherParamsParseResult<P> =
+  | { readonly ok: true; readonly value: P }
+  | { readonly ok: false; readonly error: CipherValidationError };
+
+// --- Definição de cifra ---
+
+export type CipherDefinition<P = EmptyCipherParams> = {
+  readonly id: CipherId;
+  readonly name: string;
+  readonly paramFields: readonly CipherParamField[];
+  readonly encode: (plainText: string, params: P) => string;
+  readonly decode: (cipherText: string, params: P) => string;
+  /**
+   * Opcional: normaliza `unknown` (ex.: body JSON) para `P`.
+   * Deve lançar {@link CipherValidationError} ou retornar {@link CipherParamsParseResult} conforme a implementação escolher.
+   */
+  readonly parseParams?: (raw: unknown) => P | CipherParamsParseResult<P>;
 };


### PR DESCRIPTION
## Contexto
Implementa a issue [#6](https://github.com/SoGabiMano/Cypher-Vault/issues/6) (CV-004).

## O que mudou
- Contrato `CipherDefinition<P>` com `id`, `name`, `paramFields`, `encode` / `decode` e `parseParams?` opcional em `types/cipher.ts`.
- Descritores `CipherParamField` (number | string) para formulário dinâmico futuro (CV-013).
- `CipherValidationError`, `isCipherValidationError` e `CipherParamsParseResult<P>`.
- `CipherMetadata` passa a usar `name` em vez de `label` (UI e testes atualizados).
- Exemplos em `lib/ciphers/`: `identityCipher` e `caesarCipher` com `parseCaesarParams`.
- Testes em `types/cipher.test.ts` e `lib/ciphers/*.test.ts`.

## Definition of Done (issue)
- [x] Tipos exportados e consumíveis por `lib/ciphers/*`
- [x] Sem `any` nos pontos públicos do contrato
- [ ] Revisão por Dev B (pendente)

Fixes #6

Made with [Cursor](https://cursor.com)