### PR TITLE
feat: cipher registry com ids únicos

### DIFF
--- a/docs/REPOSITORY_RULES.md
+++ b/docs/REPOSITORY_RULES.md
@@ -1,0 +1,9 @@
+# Regras do repositório
+
+## 1) Nomes de variáveis (SOLID + Clean Code)
+
+- **Clareza acima de abreviações**: variáveis (incluindo env vars / “variáveis do sistema”) devem seguir princípios de **SOLID** e **Clean Code**, com nomes **claros e objetivos** sobre o que representam.
+- **Proibido**: nomes de 1 letra ou abreviações/resumos (ex.: `x`, `a`, `cfg`, `tmp`, `val`) quando isso reduzir entendimento.
+- **Tamanho**: evitar nomes muito extensos que cheguem perto ou passem de **20 caracteres**.
+  - Exceções aceitáveis: quando necessário para identificação inequívoca, ou em nomes de funções/assinaturas onde o ganho de clareza compense.
+

--- a/lib/ciphers/caesar.ts
+++ b/lib/ciphers/caesar.ts
@@ -65,7 +65,7 @@ export function parseCaesarParams(raw: unknown): CaesarParams {
 }
 
 /** César apenas sobre A–Z / a–z; demais code points são preservados. */
-export const caesarCipher: CipherDefinition<CaesarParams> = {
+export const caesarCipher = {
   id: "caesar",
   name: "Caesar",
   paramFields: [
@@ -81,4 +81,4 @@ export const caesarCipher: CipherDefinition<CaesarParams> = {
   encode: (plainText, params) => transform(plainText, params.shift, false),
   decode: (cipherText, params) => transform(cipherText, params.shift, true),
   parseParams: parseCaesarParams,
-};
+} as const satisfies CipherDefinition<CaesarParams>;

--- a/lib/ciphers/identity.ts
+++ b/lib/ciphers/identity.ts
@@ -1,7 +1,7 @@
 import type { CipherDefinition, EmptyCipherParams } from "@/types/cipher";
 
 /** Cifra identidade: útil para testes de registry e smoke de imports `lib/ciphers/*`. */
-export const identityCipher: CipherDefinition<EmptyCipherParams> = {
+export const identityCipher = {
   id: "identity",
   name: "Identity",
   paramFields: [],
@@ -13,4 +13,4 @@ export const identityCipher: CipherDefinition<EmptyCipherParams> = {
     void params;
     return cipherText;
   },
-};
+} as const satisfies CipherDefinition<EmptyCipherParams>;

--- a/lib/ciphers/index.ts
+++ b/lib/ciphers/index.ts
@@ -1,2 +1,3 @@
 export { caesarCipher, parseCaesarParams, type CaesarParams } from "./caesar";
 export { identityCipher } from "./identity";
+export { cipherRegistry, getAllCiphers, getCipherById } from "./registry";

--- a/lib/ciphers/registry.test.ts
+++ b/lib/ciphers/registry.test.ts
@@ -1,0 +1,24 @@
+import { cipherRegistry, getAllCiphers, getCipherById } from "./registry";
+
+describe("cipherRegistry", () => {
+  it("lista todas as cifras do MVP", () => {
+    const ids = cipherRegistry.map((c) => c.id).sort();
+    expect(ids).toEqual(["caesar", "identity"]);
+  });
+
+  it("getAllCiphers expõe a mesma lista", () => {
+    expect(getAllCiphers()).toBe(cipherRegistry);
+  });
+
+  it("getCipherById retorna definição ou undefined", () => {
+    expect(getCipherById("caesar")?.id).toBe("caesar");
+    expect(getCipherById("identity")?.id).toBe("identity");
+    expect(getCipherById("missing")).toBeUndefined();
+  });
+
+  it("ids são únicos", () => {
+    const ids = cipherRegistry.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+

--- a/lib/ciphers/registry.ts
+++ b/lib/ciphers/registry.ts
@@ -1,0 +1,52 @@
+import type { CipherDefinition } from "@/types/cipher";
+import { caesarCipher } from "./caesar";
+import { identityCipher } from "./identity";
+
+type EnsureUniqueIds<
+  T extends readonly { readonly id: string }[],
+> = DuplicateId<T> extends infer D
+  ? [D] extends [never]
+    ? T
+    : ["Duplicate cipher id", D & string]
+  : never;
+
+type DuplicateId<
+  T extends readonly { readonly id: string }[],
+  Seen extends readonly string[] = readonly [],
+> = T extends readonly [infer H, ...infer R]
+  ? H extends { readonly id: infer I extends string }
+    ? I extends Seen[number]
+      ? I
+      : R extends readonly { readonly id: string }[]
+        ? DuplicateId<R, readonly [...Seen, I]>
+        : never
+    : never
+  : never;
+
+function defineCipherRegistry<const T extends readonly CipherDefinition<any>[]>(
+  ...ciphers: EnsureUniqueIds<T> & T
+): T {
+  return ciphers;
+}
+
+export const cipherRegistry = defineCipherRegistry(caesarCipher, identityCipher);
+
+const cipherById: ReadonlyMap<string, CipherDefinition<any>> = (() => {
+  const map = new Map<string, CipherDefinition<any>>();
+  for (const def of cipherRegistry) {
+    if (map.has(def.id)) {
+      throw new Error(`Duplicate cipher id detected: "${def.id}"`);
+    }
+    map.set(def.id, def);
+  }
+  return map;
+})();
+
+export function getAllCiphers(): readonly CipherDefinition<any>[] {
+  return cipherRegistry;
+}
+
+export function getCipherById(id: string): CipherDefinition<any> | undefined {
+  return cipherById.get(id);
+}
+


### PR DESCRIPTION
## Summary
- Adiciona `cipherRegistry` com garantia de unicidade de `id` (TypeScript + assert em runtime).
- Expõe API única para UI: `getAllCiphers()` e `getCipherById(id)`.
- Adiciona docs de regras do repositório (nomenclatura de variáveis).

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`

## Issue
- Closes #7

Made with [Cursor](https://cursor.com)