### PR TITLE
feat(ciphers): add Atbash cipher (#10)

### DIFF
--- a/lib/ciphers/atbash.test.ts
+++ b/lib/ciphers/atbash.test.ts
@@ -1,0 +1,16 @@
+import { atbashCipher } from "./atbash";
+
+describe("atbashCipher", () => {
+  it("espelha letras ASCII e preserva não-letras", () => {
+    const plain = "AbC z! 123 áéí🙂";
+    const enc = atbashCipher.encode(plain, undefined);
+    expect(enc).toBe("ZyX a! 123 áéí🙂");
+    expect(atbashCipher.decode(enc, undefined)).toBe(plain);
+  });
+
+  it("exemplo do documento: HELLO -> SVOOL (encode = decode)", () => {
+    expect(atbashCipher.encode("HELLO", undefined)).toBe("SVOOL");
+    expect(atbashCipher.decode("HELLO", undefined)).toBe("SVOOL");
+  });
+});
+

--- a/lib/ciphers/atbash.ts
+++ b/lib/ciphers/atbash.ts
@@ -1,0 +1,57 @@
+import type { CipherDefinition, EmptyCipherParams } from "@/types/cipher";
+
+const ASCII_UPPER_A = 65;
+const ASCII_UPPER_Z = 90;
+const ASCII_LOWER_A = 97;
+const ASCII_LOWER_Z = 122;
+
+function mirrorAsciiLetter(code: number, baseA: number, baseZ: number): number {
+  return baseZ - (code - baseA);
+}
+
+function transform(text: string): string {
+  let out = "";
+  for (const ch of text) {
+    const code = ch.codePointAt(0);
+    if (code === undefined) {
+      out += ch;
+      continue;
+    }
+
+    if (ch.length === 1 && code >= ASCII_UPPER_A && code <= ASCII_UPPER_Z) {
+      out += String.fromCodePoint(mirrorAsciiLetter(code, ASCII_UPPER_A, ASCII_UPPER_Z));
+      continue;
+    }
+
+    if (ch.length === 1 && code >= ASCII_LOWER_A && code <= ASCII_LOWER_Z) {
+      out += String.fromCodePoint(mirrorAsciiLetter(code, ASCII_LOWER_A, ASCII_LOWER_Z));
+      continue;
+    }
+
+    out += ch;
+  }
+  return out;
+}
+
+/**
+ * Atbash (A↔Z, B↔Y, …) apenas sobre A–Z / a–z.
+ *
+ * Regras:
+ * - transforma somente letras ASCII latinas (A–Z, a–z)
+ * - preserva qualquer outro caractere (pontuação, números, acentos, emojis, etc.)
+ * - encode e decode são a mesma operação
+ */
+export const atbashCipher = {
+  id: "atbash",
+  name: "Atbash",
+  paramFields: [],
+  encode: (plainText, params) => {
+    void params;
+    return transform(plainText);
+  },
+  decode: (cipherText, params) => {
+    void params;
+    return transform(cipherText);
+  },
+} as const satisfies CipherDefinition<EmptyCipherParams>;
+

--- a/lib/ciphers/index.ts
+++ b/lib/ciphers/index.ts
@@ -1,3 +1,4 @@
+export { atbashCipher } from "./atbash";
 export { caesarCipher, parseCaesarParams, type CaesarParams } from "./caesar";
 export { identityCipher } from "./identity";
 export { cipherRegistry, getAllCiphers, getCipherById } from "./registry";

--- a/lib/ciphers/registry.test.ts
+++ b/lib/ciphers/registry.test.ts
@@ -3,7 +3,7 @@ import { cipherRegistry, getAllCiphers, getCipherById } from "./registry";
 describe("cipherRegistry", () => {
   it("lista todas as cifras do MVP", () => {
     const ids = cipherRegistry.map((c) => c.id).sort();
-    expect(ids).toEqual(["caesar", "identity"]);
+    expect(ids).toEqual(["atbash", "caesar", "identity"]);
   });
 
   it("getAllCiphers expõe a mesma lista", () => {

--- a/lib/ciphers/registry.ts
+++ b/lib/ciphers/registry.ts
@@ -1,4 +1,5 @@
 import type { CipherDefinition } from "@/types/cipher";
+import { atbashCipher } from "./atbash";
 import { caesarCipher } from "./caesar";
 import { identityCipher } from "./identity";
 
@@ -23,16 +24,20 @@ type DuplicateId<
     : never
   : never;
 
-function defineCipherRegistry<const T extends readonly CipherDefinition<any>[]>(
+function defineCipherRegistry<const T extends readonly CipherDefinition<unknown>[]>(
   ...ciphers: EnsureUniqueIds<T> & T
 ): T {
   return ciphers;
 }
 
-export const cipherRegistry = defineCipherRegistry(caesarCipher, identityCipher);
+export const cipherRegistry = defineCipherRegistry(
+  atbashCipher,
+  caesarCipher,
+  identityCipher,
+);
 
-const cipherById: ReadonlyMap<string, CipherDefinition<any>> = (() => {
-  const map = new Map<string, CipherDefinition<any>>();
+const cipherById: ReadonlyMap<string, CipherDefinition<unknown>> = (() => {
+  const map = new Map<string, CipherDefinition<unknown>>();
   for (const def of cipherRegistry) {
     if (map.has(def.id)) {
       throw new Error(`Duplicate cipher id detected: "${def.id}"`);
@@ -42,11 +47,11 @@ const cipherById: ReadonlyMap<string, CipherDefinition<any>> = (() => {
   return map;
 })();
 
-export function getAllCiphers(): readonly CipherDefinition<any>[] {
+export function getAllCiphers(): readonly CipherDefinition<unknown>[] {
   return cipherRegistry;
 }
 
-export function getCipherById(id: string): CipherDefinition<any> | undefined {
+export function getCipherById(id: string): CipherDefinition<unknown> | undefined {
   return cipherById.get(id);
 }
 


### PR DESCRIPTION
## Summary
- Implement Atbash cipher (A↔Z / a↔z) with encode=decode and non-letter preservation.
- Register `atbash` in `cipherRegistry` and export it via `lib/ciphers/index.ts`.
- Add Jest tests for doc example (HELLO→SVOOL) and mixed/unicode preservation.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run lint`

Closes #10.

Made with [Cursor](https://cursor.com)