### PR TITLE
feat(ciphers): cifra de Vigenère (#11)

### DIFF
--- a/lib/ciphers/index.ts
+++ b/lib/ciphers/index.ts
@@ -2,4 +2,5 @@ export { atbashCipher } from "./atbash";
 export { caesarCipher, parseCaesarParams, type CaesarParams } from "./caesar";
 export { identityCipher } from "./identity";
 export { morseCipher, decodeMorse, encodeMorse } from "./morse";
+export { vigenereCipher, parseVigenereParams, type VigenereParams } from "./vigenere";
 export { cipherRegistry, getAllCiphers, getCipherById } from "./registry";

--- a/lib/ciphers/registry.test.ts
+++ b/lib/ciphers/registry.test.ts
@@ -3,7 +3,7 @@ import { cipherRegistry, getAllCiphers, getCipherById } from "./registry";
 describe("cipherRegistry", () => {
   it("lista todas as cifras do MVP", () => {
     const ids = cipherRegistry.map((c) => c.id).sort();
-    expect(ids).toEqual(["atbash", "caesar", "identity", "morse"]);
+    expect(ids).toEqual(["atbash", "caesar", "identity", "morse", "vigenere"]);
   });
 
   it("getAllCiphers expõe a mesma lista", () => {
@@ -13,6 +13,7 @@ describe("cipherRegistry", () => {
   it("getCipherById retorna definição ou undefined", () => {
     expect(getCipherById("caesar")?.id).toBe("caesar");
     expect(getCipherById("identity")?.id).toBe("identity");
+    expect(getCipherById("vigenere")?.id).toBe("vigenere");
     expect(getCipherById("missing")).toBeUndefined();
   });
 

--- a/lib/ciphers/registry.ts
+++ b/lib/ciphers/registry.ts
@@ -3,9 +3,9 @@ import { atbashCipher } from "./atbash";
 import { caesarCipher } from "./caesar";
 import { identityCipher } from "./identity";
 import { morseCipher } from "./morse";
+import { vigenereCipher } from "./vigenere";
 
-export const cipherRegistry = [atbashCipher, caesarCipher, identityCipher, morseCipher] as const;
-
+export const cipherRegistry = [atbashCipher, caesarCipher, identityCipher, morseCipher, vigenereCipher] as const;
 const cipherById: ReadonlyMap<string, CipherDefinition<unknown>> = (() => {
   const map = new Map<string, CipherDefinition<unknown>>();
   for (const def of cipherRegistry) {

--- a/lib/ciphers/vigenere.test.ts
+++ b/lib/ciphers/vigenere.test.ts
@@ -1,0 +1,55 @@
+import { CipherValidationError } from "@/types/cipher";
+import { parseVigenereParams, vigenereCipher } from "./vigenere";
+
+describe("parseVigenereParams", () => {
+  it("aceita objeto com key e normaliza para uppercase", () => {
+    expect(parseVigenereParams({ key: "kEy" })).toEqual({ key: "KEY" });
+  });
+
+  it("aceita objeto com keyword (alias) e normaliza para uppercase", () => {
+    expect(parseVigenereParams({ keyword: "key" })).toEqual({ key: "KEY" });
+  });
+
+  it("rejeita não-objeto", () => {
+    expect(() => parseVigenereParams(null)).toThrow(CipherValidationError);
+  });
+
+  it("rejeita key ausente", () => {
+    expect(() => parseVigenereParams({})).toThrow(CipherValidationError);
+  });
+
+  it("rejeita key vazia", () => {
+    expect(() => parseVigenereParams({ key: "   " })).toThrow(CipherValidationError);
+  });
+
+  it("rejeita key com caracteres inválidos", () => {
+    expect(() => parseVigenereParams({ key: "KE-Y" })).toThrow(CipherValidationError);
+    expect(() => parseVigenereParams({ key: "K3Y" })).toThrow(CipherValidationError);
+  });
+});
+
+describe("vigenereCipher", () => {
+  it("CODE + KEY -> MSBO", () => {
+    const params = { key: "KEY" };
+    expect(vigenereCipher.encode("CODE", params)).toBe("MSBO");
+    expect(vigenereCipher.decode("MSBO", params)).toBe("CODE");
+  });
+
+  it("preserva não-letras e não avança key nelas", () => {
+    const params = { key: "A" }; // shift 0, efeito visual só para avançar key
+    expect(vigenereCipher.encode("A A!", params)).toBe("A A!");
+  });
+
+  it("roundtrip preserva case e pontuação", () => {
+    const params = { key: "Key" }; // parseParams normaliza; encode/decode usa key direto
+    const parsed = parseVigenereParams({ key: params.key });
+    const plain = "AbC z!";
+    const enc = vigenereCipher.encode(plain, parsed);
+    expect(vigenereCipher.decode(enc, parsed)).toBe(plain);
+  });
+
+  it("parseParams está disponível na definição", () => {
+    expect(vigenereCipher.parseParams).toBe(parseVigenereParams);
+  });
+});
+

--- a/lib/ciphers/vigenere.ts
+++ b/lib/ciphers/vigenere.ts
@@ -1,0 +1,119 @@
+import { CipherValidationError, type CipherDefinition, type KeyStringCipherParams } from "@/types/cipher";
+
+export type VigenereParams = KeyStringCipherParams;
+
+const ALPHABET_SIZE = 26;
+
+function isAsciiUpperLetter(code: number): boolean {
+  return code >= 65 && code <= 90;
+}
+
+function isAsciiLowerLetter(code: number): boolean {
+  return code >= 97 && code <= 122;
+}
+
+function shiftLetter(code: number, base: number, shift: number): number {
+  const i = code - base;
+  const j = (i + shift) % ALPHABET_SIZE;
+  return base + (j < 0 ? j + ALPHABET_SIZE : j);
+}
+
+function normalizeKey(rawKey: string): string {
+  const key = rawKey.trim();
+  if (key.length === 0) {
+    throw new CipherValidationError('"key" cannot be empty.', {
+      code: "PARAM_EMPTY",
+      field: "key",
+    });
+  }
+
+  if (!/^[A-Za-z]+$/.test(key)) {
+    throw new CipherValidationError('"key" must contain only letters A–Z.', {
+      code: "PARAM_FORMAT",
+      field: "key",
+    });
+  }
+
+  return key.toUpperCase();
+}
+
+export function parseVigenereParams(raw: unknown): VigenereParams {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new CipherValidationError("Parameters must be a plain object.", {
+      code: "PARAMS_OBJECT",
+      field: "*",
+    });
+  }
+  const rec = raw as Record<string, unknown>;
+
+  // Aceita também "keyword" como alias (por compatibilidade com a linguagem da issue).
+  const keyRaw = (rec.key ?? rec.keyword) as unknown;
+  if (keyRaw === undefined) {
+    throw new CipherValidationError('Missing required field "key".', {
+      code: "PARAM_MISSING",
+      field: "key",
+    });
+  }
+  if (typeof keyRaw !== "string") {
+    throw new CipherValidationError('"key" must be a string.', {
+      code: "PARAM_TYPE",
+      field: "key",
+    });
+  }
+
+  return { key: normalizeKey(keyRaw) };
+}
+
+function transform(text: string, key: string, decrypt: boolean): string {
+  let out = "";
+  let keyIndex = 0;
+
+  for (const ch of text) {
+    const code = ch.codePointAt(0);
+    if (code === undefined) {
+      out += ch;
+      continue;
+    }
+
+    if (ch.length === 1 && (isAsciiUpperLetter(code) || isAsciiLowerLetter(code))) {
+      const k = key.codePointAt(keyIndex % key.length);
+      // key é sempre A–Z após normalizeKey, então k não deve ser undefined.
+      const shift = k === undefined ? 0 : k - 65;
+      const delta = decrypt ? -shift : shift;
+      const base = isAsciiUpperLetter(code) ? 65 : 97;
+      out += String.fromCodePoint(shiftLetter(code, base, delta));
+      keyIndex += 1;
+      continue;
+    }
+
+    out += ch;
+  }
+
+  return out;
+}
+
+/**
+ * Vigenère em letras ASCII (A–Z / a–z).
+ *
+ * - `key` aceita A–Z (case-insensitive) e é normalizada para uppercase.
+ * - Caracteres não-letra são preservados e **não** avançam o índice da key.
+ */
+export const vigenereCipher = {
+  id: "vigenere",
+  name: "Vigenère",
+  paramFields: [
+    {
+      kind: "string",
+      key: "key",
+      label: "Key",
+      description: "Alphabetic keyword (A–Z). Case-insensitive.",
+      required: true,
+      minLength: 1,
+      pattern: "^[A-Za-z]+$",
+    },
+  ],
+  encode: (plainText, params) => transform(plainText, params.key, false),
+  decode: (cipherText, params) => transform(cipherText, params.key, true),
+  parseParams: parseVigenereParams,
+} as const satisfies CipherDefinition<VigenereParams>;
+


### PR DESCRIPTION
## Contexto

Implementa a cifra de **Vigenère** conforme a issue #11, adicionando suporte a uma palavra‑chave alfabética repetida para deslocamento polialfabético.

Closes #11

## O que foi implementado

- **Nova cifra**: `lib/ciphers/vigenere.ts`
  - `vigenereCipher` com `encode`/`decode` (funções puras)
  - **Válido para letras ASCII** `A–Z` e `a–z`
  - **Preserva não‑letras** (espaços/pontuação/etc.)
  - **Índice da key só avança em letras** (não avança em não‑letras)
  - `parseVigenereParams` com validação previsível via `CipherValidationError`
    - `key` obrigatório, string não vazia
    - aceita apenas letras (`A–Z`), **case-insensitive**, normaliza para uppercase
    - aceita `keyword` como alias de `key` (compatibilidade com a linguagem da issue)

- **Registry**
  - Registro no `cipherRegistry` em `lib/ciphers/registry.ts`
  - Exports adicionados em `lib/ciphers/index.ts`

- **Testes**
  - `lib/ciphers/vigenere.test.ts`:
    - exemplo do doc: `CODE` + `KEY` → `MSBO` (encode e decode)
    - validações: key ausente, vazia, com caracteres inválidos
    - preservação de não‑letras e roundtrip com case/pontuação
  - Ajuste em `lib/ciphers/registry.test.ts` para incluir `vigenere`

## Decisões e comportamento

- **Case**
  - `key`: aceita minúsculas e normaliza para uppercase no parse.
  - `text`: mantém o case original; aplica deslocamento respeitando base `A`/`a`.

- **Não‑letras**
  - são preservadas e **não consomem** caracteres da key.

## Como testar

```bash
npm test
npm run typecheck
npm run lint
```

## Checklist

- [x] Implementação da cifra em `lib/ciphers/vigenere.ts`
- [x] Registro no `cipherRegistry`
- [x] Testes cobrindo exemplo e validações
- [x] Lint e typecheck ok

Made with [Cursor](https://cursor.com)