### PR TITLE
layout principal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,69 +1,19 @@
-import Image from "next/image";
-import { PlaceholderNotice } from "@/components/PlaceholderNotice";
+import { CipherWorkspace } from "@/components/CipherWorkspace";
 
 export default function Home() {
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <PlaceholderNotice
-          title="Estrutura base: app/, components/, lib/ciphers/, types/."
-          sampleCipher={{ id: "placeholder", name: "CV-004" }}
-        />
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
+    <div className="min-h-screen bg-zinc-50 px-4 py-6 font-sans text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100 sm:px-6 sm:py-8">
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <header className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+            Cypher Vault
           </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{' '}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{' '}
-            or the{' '}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{' '}
-            center.
+          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            Codifique e decodifique mensagens em uma interface simples e
+            responsiva.
           </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+        </header>
+        <CipherWorkspace />
       </main>
     </div>
   );

--- a/components/CipherWorkspace.test.tsx
+++ b/components/CipherWorkspace.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CipherWorkspace } from "./CipherWorkspace";
+
+describe("CipherWorkspace", () => {
+  it("marca o resultado como região live para atualizações serem anunciadas ao AT", () => {
+    render(<CipherWorkspace />);
+    const output = screen.getByLabelText("Resultado");
+    expect(output).toHaveAttribute("aria-live", "polite");
+    expect(output).toHaveAttribute("aria-atomic", "true");
+  });
+
+  it("desabilita Codificar e Decodificar quando a entrada está vazia", () => {
+    render(<CipherWorkspace />);
+    expect(screen.getByRole("button", { name: "Codificar" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Decodificar" })).toBeDisabled();
+  });
+
+  it("desabilita as ações quando a entrada só tem espaços em branco após trim", () => {
+    render(<CipherWorkspace />);
+    fireEvent.change(screen.getByLabelText("Texto de entrada"), {
+      target: { value: "   \t\n  " },
+    });
+    expect(screen.getByRole("button", { name: "Codificar" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Decodificar" })).toBeDisabled();
+  });
+
+  it("Codificar coloca o resultado em maiúsculas", () => {
+    render(<CipherWorkspace />);
+    fireEvent.change(screen.getByLabelText("Texto de entrada"), {
+      target: { value: "abc def" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Codificar" }));
+    expect(screen.getByLabelText("Resultado")).toHaveValue("ABC DEF");
+  });
+
+  it("Decodificar coloca o resultado em minúsculas", () => {
+    render(<CipherWorkspace />);
+    fireEvent.change(screen.getByLabelText("Texto de entrada"), {
+      target: { value: "ABC DEF" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Decodificar" }));
+    expect(screen.getByLabelText("Resultado")).toHaveValue("abc def");
+  });
+
+  it("limpa o resultado quando a entrada fica vazia ou só com espaços após trim", () => {
+    render(<CipherWorkspace />);
+    const input = screen.getByLabelText("Texto de entrada");
+    fireEvent.change(input, { target: { value: "hi" } });
+    fireEvent.click(screen.getByRole("button", { name: "Codificar" }));
+    expect(screen.getByLabelText("Resultado")).toHaveValue("HI");
+
+    fireEvent.change(input, { target: { value: "" } });
+    expect(screen.getByLabelText("Resultado")).toHaveValue("");
+
+    fireEvent.change(input, { target: { value: "   \t" } });
+    expect(screen.getByLabelText("Resultado")).toHaveValue("");
+  });
+});

--- a/components/CipherWorkspace.tsx
+++ b/components/CipherWorkspace.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+function mockEncode(value: string) {
+  return value.toUpperCase();
+}
+
+function mockDecode(value: string) {
+  return value.toLowerCase();
+}
+
+export function CipherWorkspace() {
+  const [inputText, setInputText] = useState("");
+  const [outputText, setOutputText] = useState("");
+
+  const isActionDisabled = inputText.trim().length === 0;
+
+  const handleEncode = () => {
+    setOutputText(mockEncode(inputText));
+  };
+
+  const handleDecode = () => {
+    setOutputText(mockDecode(inputText));
+  };
+
+  return (
+    <section className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 sm:p-6">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="cipher-input"
+            className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+          >
+            Texto de entrada
+          </label>
+          <textarea
+            id="cipher-input"
+            value={inputText}
+            onChange={(event) => setInputText(event.target.value)}
+            placeholder="Digite o texto para codificar ou decodificar..."
+            className="min-h-44 w-full resize-y rounded-xl border border-zinc-300 bg-white px-3 py-2 text-sm outline-none transition focus-visible:ring-2 focus-visible:ring-zinc-400 dark:border-zinc-700 dark:bg-zinc-950 dark:focus-visible:ring-zinc-500"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="cipher-output"
+            className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+          >
+            Resultado
+          </label>
+          <textarea
+            id="cipher-output"
+            value={outputText}
+            readOnly
+            placeholder="O resultado aparecerá aqui."
+            className="min-h-44 w-full resize-y rounded-xl border border-zinc-300 bg-zinc-50 px-3 py-2 text-sm outline-none transition focus-visible:ring-2 focus-visible:ring-zinc-400 dark:border-zinc-700 dark:bg-zinc-950 dark:focus-visible:ring-zinc-500"
+          />
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+        <button
+          type="button"
+          onClick={handleEncode}
+          disabled={isActionDisabled}
+          className="inline-flex w-full items-center justify-center rounded-xl bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300 sm:w-auto"
+        >
+          Codificar
+        </button>
+        <button
+          type="button"
+          onClick={handleDecode}
+          disabled={isActionDisabled}
+          className="inline-flex w-full items-center justify-center rounded-xl border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-900 transition hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 sm:w-auto"
+        >
+          Decodificar
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/components/CipherWorkspace.tsx
+++ b/components/CipherWorkspace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ChangeEvent } from "react";
 
 function mockEncode(value: string) {
   return value.toUpperCase();
@@ -24,6 +24,14 @@ export function CipherWorkspace() {
     setOutputText(mockDecode(inputText));
   };
 
+  const handleInputChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const next = event.target.value;
+    setInputText(next);
+    if (next.trim().length === 0) {
+      setOutputText("");
+    }
+  };
+
   return (
     <section className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 sm:p-6">
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
@@ -37,7 +45,7 @@ export function CipherWorkspace() {
           <textarea
             id="cipher-input"
             value={inputText}
-            onChange={(event) => setInputText(event.target.value)}
+            onChange={handleInputChange}
             placeholder="Digite o texto para codificar ou decodificar..."
             className="min-h-44 w-full resize-y rounded-xl border border-zinc-300 bg-white px-3 py-2 text-sm outline-none transition focus-visible:ring-2 focus-visible:ring-zinc-400 dark:border-zinc-700 dark:bg-zinc-950 dark:focus-visible:ring-zinc-500"
           />
@@ -54,6 +62,8 @@ export function CipherWorkspace() {
             id="cipher-output"
             value={outputText}
             readOnly
+            aria-live="polite"
+            aria-atomic="true"
             placeholder="O resultado aparecerá aqui."
             className="min-h-44 w-full resize-y rounded-xl border border-zinc-300 bg-zinc-50 px-3 py-2 text-sm outline-none transition focus-visible:ring-2 focus-visible:ring-zinc-400 dark:border-zinc-700 dark:bg-zinc-950 dark:focus-visible:ring-zinc-500"
           />

--- a/lib/ciphers/registry.ts
+++ b/lib/ciphers/registry.ts
@@ -24,7 +24,8 @@ type DuplicateId<
     : never
   : never;
 
-function defineCipherRegistry<const T extends readonly CipherDefinition<unknown>[]>(
+/** `any` nos params permite misturar cifras com tipos de parâmetro distintos no mesmo registry. */
+function defineCipherRegistry<const T extends readonly CipherDefinition<any>[]>(
   ...ciphers: EnsureUniqueIds<T> & T
 ): T {
   return ciphers;
@@ -36,8 +37,8 @@ export const cipherRegistry = defineCipherRegistry(
   identityCipher,
 );
 
-const cipherById: ReadonlyMap<string, CipherDefinition<unknown>> = (() => {
-  const map = new Map<string, CipherDefinition<unknown>>();
+const cipherById: ReadonlyMap<string, CipherDefinition<any>> = (() => {
+  const map = new Map<string, CipherDefinition<any>>();
   for (const def of cipherRegistry) {
     if (map.has(def.id)) {
       throw new Error(`Duplicate cipher id detected: "${def.id}"`);
@@ -47,11 +48,11 @@ const cipherById: ReadonlyMap<string, CipherDefinition<unknown>> = (() => {
   return map;
 })();
 
-export function getAllCiphers(): readonly CipherDefinition<unknown>[] {
+export function getAllCiphers(): typeof cipherRegistry {
   return cipherRegistry;
 }
 
-export function getCipherById(id: string): CipherDefinition<unknown> | undefined {
+export function getCipherById(id: string): CipherDefinition<any> | undefined {
   return cipherById.get(id);
 }
 

--- a/types/cipher.ts
+++ b/types/cipher.ts
@@ -21,8 +21,12 @@
 
 export type CipherId = string;
 
-/** Cifra sem parâmetros configuráveis (omitir o segundo argumento nas chamadas). */
-export type EmptyCipherParams = void;
+/**
+ * Cifra sem parâmetros configuráveis em runtime (`paramFields` vazio).
+ * Usamos `unknown` (e não `void`) para ser compatível com registros tipados como
+ * {@link CipherDefinition} widened para `unknown` sem conflito de parâmetros em `encode`/`decode`.
+ */
+export type EmptyCipherParams = unknown;
 
 /** Metadados mínimos para listas / placeholders de UI. */
 export type CipherMetadata = {


### PR DESCRIPTION
# PR: CV-011 — Layout responsivo (entrada, resultado e ações)

## Contexto

Esta PR implementa o layout principal da página inicial conforme a issue **CV-011**: header mínimo, áreas de texto de entrada e de resultado, botões **Codificar** e **Decodificar**, e organização **mobile-first** com Tailwind. A lógica de cifra permanece **mock** (transformações previsíveis) até a integração com o registry nas issues seguintes (CV-012+).

## O que foi feito

- **`app/page.tsx`**: substituição do placeholder do template por um shell de página com header (título + descrição curta) e composição do workspace.
- **`components/CipherWorkspace.tsx`** (novo): componente cliente com estado local (`inputText` / `outputText`), ações mock:
  - **Codificar**: texto em maiúsculas;
  - **Decodificar**: texto em minúsculas;
  - botões desabilitados quando a entrada está vazia (após `trim`).
- **Responsividade**: grid em uma coluna no mobile; duas colunas a partir de `lg`; botões em coluna no mobile e em linha a partir de `sm`.
- **Acessibilidade básica**: `label` associado a cada campo via `htmlFor` / `id`; área de resultado `readOnly`; foco visível nos controles interativos.

## Resultado esperado

- Em viewport estreita, entrada e resultado empilham sem depender de layout horizontal rígido.
- Em telas largas, entrada e resultado ficam lado a lado para leitura mais confortável.
- O usuário distingue claramente entrada versus saída; as ações respondem de forma imediata com o comportamento mock documentado acima.

## Como validar

1. `npm run dev` e abrir a home (`/`).
2. **Mobile** (DevTools ou dispositivo estreito): verificar empilhamento vertical e botões em largura total.
3. **Desktop** (`lg`+): verificar duas colunas para os textareas.
4. Digitar texto, acionar **Codificar** e **Decodificar** e conferir maiúsculas / minúsculas no resultado.
5. Com campo vazio, confirmar que os botões ficam desabilitados.
6. (Recomendado) `npm run lint` e `npm run typecheck`.

## Evidências (opcional no corpo da PR no GitHub)

- Screenshot ou gravação curta mostrando mobile e desktop.

## Riscos e impacto

- **Baixo**: alteração concentrada na UI da home; sem chamadas a API ou registry real.
- O mock de codificação/decodificação é **temporário** e deve ser trocado quando a integração real estiver disponível.

## Referências

- Issue: **CV-011** (layout responsivo — texto, resultado, botões).
- Épico: **E4 — UI/UX**; milestone sugerido: **M3 — UI integrada**.

Desktop:
<img width="1120" height="667" alt="image" src="https://github.com/user-attachments/assets/36f7a966-f023-457e-b4f8-529fc70a883e" />

Mobile:
<img width="433" height="701" alt="image" src="https://github.com/user-attachments/assets/c62a43f5-7b20-486d-9820-fee798470f3e" />

