### PR TITLE
feat: testes exemplos cypher-vault-ideia e documentação de testes (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,17 @@ npm run lint
 npm run typecheck
 npm run format
 npm run format:check
+npm test
 
 # (alternativa)
 pnpm lint
 pnpm typecheck
 pnpm format
 pnpm format:check
+pnpm test
 ```
+
+Testes unitários (Jest): a suíte das cifras fica em `lib/ciphers/*.test.ts` (demais testes em `**/*.test.ts` na raiz). Para modo watch: `npm run test:watch` ou `pnpm test:watch`.
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 

--- a/lib/ciphers/atbash.test.ts
+++ b/lib/ciphers/atbash.test.ts
@@ -8,7 +8,7 @@ describe("atbashCipher", () => {
     expect(atbashCipher.decode(enc, undefined)).toBe(plain);
   });
 
-  it("exemplo do documento: HELLO -> SVOOL (encode = decode)", () => {
+  it("exemplo cypher-vault-ideia (Atbash): HELLO -> SVOOL (encode = decode)", () => {
     expect(atbashCipher.encode("HELLO", undefined)).toBe("SVOOL");
     expect(atbashCipher.decode("HELLO", undefined)).toBe("SVOOL");
   });

--- a/lib/ciphers/caesar.test.ts
+++ b/lib/ciphers/caesar.test.ts
@@ -28,6 +28,13 @@ describe("caesarCipher", () => {
     expect(caesarCipher.decode(enc, params)).toBe(plain);
   });
 
+  it("exemplo do documento (César): DEV com shift 3 -> GHY e roundtrip", () => {
+    const params = { shift: 3 };
+    const enc = caesarCipher.encode("DEV", params);
+    expect(enc).toBe("GHY");
+    expect(caesarCipher.decode(enc, params)).toBe("DEV");
+  });
+
   it("parseParams está disponível na definição", () => {
     expect(caesarCipher.parseParams).toBe(parseCaesarParams);
   });

--- a/lib/ciphers/morse.test.ts
+++ b/lib/ciphers/morse.test.ts
@@ -2,7 +2,7 @@ import { CipherValidationError } from "@/types/cipher";
 import { decodeMorse, encodeMorse, morseCipher } from "./morse";
 
 describe("morseCipher", () => {
-  it("encode SOS e decode retorna lowercase", () => {
+  it("exemplo cypher-vault-ideia (Morse): SOS -> ... --- ...; decode retorna lowercase", () => {
     const enc = morseCipher.encode("SOS", undefined);
     expect(enc).toBe("... --- ...");
     expect(morseCipher.decode(enc, undefined)).toBe("sos");

--- a/lib/ciphers/vigenere.test.ts
+++ b/lib/ciphers/vigenere.test.ts
@@ -29,7 +29,7 @@ describe("parseVigenereParams", () => {
 });
 
 describe("vigenereCipher", () => {
-  it("CODE + KEY -> MSBO", () => {
+  it("exemplo cypher-vault-ideia (Vigenère): CODE + KEY -> MSBO", () => {
     const params = { key: "KEY" };
     expect(vigenereCipher.encode("CODE", params)).toBe("MSBO");
     expect(vigenereCipher.decode("MSBO", params)).toBe("CODE");


### PR DESCRIPTION
## Resumo

Esta pull request fecha o escopo da issue **#17** (CV-015): garantir cobertura explícita dos exemplos do documento *cypher-vault-ideia* nos testes Jest das cifras e documentar no README como executar a suíte de testes.

Não há mudança de comportamento das implementações em `lib/ciphers/*.ts` — apenas testes e documentação.

---

## Contexto

- **Issue:** https://github.com/SoGabiMano/Cypher-Vault/issues/17  
- **Milestone:** M2 — Núcleo de cifras + testes  
- O repositório já utilizava **Jest** (`jest.config.js`, script `test` no `package.json`). Esta PR não introduz Vitest nem novas dependências.

---

## O que foi alterado

### Testes (`lib/ciphers/*.test.ts`)

| Área | Mudança |
|------|---------|
| **César** | Novo caso de teste alinhado ao doc: texto `DEV`, parâmetro `shift: 3`, esperado `GHY`, com asserção de roundtrip via `decode`. |
| **Atbash** | Título do `it` do exemplo `HELLO` → `SVOOL` ajustado para deixar explícita a origem (*cypher-vault-ideia*). Asserções inalteradas. |
| **Vigenère** | Mesmo tipo de ajuste de nomenclatura para o exemplo `CODE` + chave `KEY` → `MSBO`. |
| **Morse** | Mesmo tipo de ajuste para `SOS` → `... --- ...` e decode em minúsculas. |

Os testes de validação já existentes (por exemplo keyword vazia ou inválida no Vigenère, token Morse inválido com `CipherValidationError` / `MALFORMED_INPUT_DATA`) foram mantidos; não houve reescrita desnecessária das suites.

### Documentação (`README.md`)

- Inclusão de `npm test` e `pnpm test` na seção **Scripts úteis**.  
- Menção a `npm run test:watch` / `pnpm test:watch`.  
- Frase indicando que os testes das cifras residem em `lib/ciphers/*.test.ts` e que outros testes seguem o padrão `**/*.test.ts`.

---

## Como validar localmente

Na raiz do repositório (após `npm ci` ou `npm install`):

```bash
npm test
```

Ou, com pnpm:

```bash
pnpm test
```

Opcional: `npm run lint`, `npm run typecheck`.

---

## Critérios da issue (#17) — status

- [x] Teste explícito César: `DEV` com deslocamento 3 → `GHY` e volta com `decode`.  
- [x] Cobertura dos exemplos Atbash `HELLO` → `SVOOL`, Vigenère `CODE` + `KEY` → `MSBO`, Morse `SOS` → `... --- ...` (com títulos de teste legíveis).  
- [x] Validação mínima Vigenère e Morse inválido já presentes na suíte existente.  
- [x] README documenta execução dos testes.  
- [x] `pnpm test` / `npm test` passa (verificação local no branch).

---

## Notas para revisores

- Branch criada a partir do mesmo tip que `17-testes-unitarios` para isolar o trabalho em `feat/17` sem conflito de checkout duplicado em worktree.  
- Nenhum arquivo de lock novo foi adicionado; o projeto continua padronizado em `package-lock.json`.


---

Closes #17
