### PR TITLE
seletor de cifras

### DIFF
--- a/components/CipherSelector.test.tsx
+++ b/components/CipherSelector.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CipherSelector } from "./CipherSelector";
+
+const sampleCiphers = [
+  { id: "alpha", name: "Alpha Cipher" },
+  { id: "beta", name: "Beta Cipher" },
+] as const;
+
+describe("CipherSelector", () => {
+  it("associa o label ao controle de seleção", () => {
+    render(
+      <CipherSelector
+        ciphers={sampleCiphers}
+        value="alpha"
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("Cifra")).toBe(screen.getByRole("combobox"));
+  });
+
+  it("exibe o name de cada cifra como opção", () => {
+    render(
+      <CipherSelector
+        ciphers={sampleCiphers}
+        value="alpha"
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("option", { name: "Alpha Cipher" })).toHaveValue(
+      "alpha",
+    );
+    expect(screen.getByRole("option", { name: "Beta Cipher" })).toHaveValue(
+      "beta",
+    );
+  });
+
+  it("reflete o id selecionado no valor do controle", () => {
+    render(
+      <CipherSelector
+        ciphers={sampleCiphers}
+        value="beta"
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("Cifra")).toHaveValue("beta");
+  });
+
+  it("chama onChange com o id ao trocar a opção", () => {
+    const onChange = jest.fn();
+
+    render(
+      <CipherSelector
+        ciphers={sampleCiphers}
+        value="alpha"
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Cifra"), {
+      target: { value: "beta" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("beta");
+  });
+
+  it("desabilita o controle quando disabled é true", () => {
+    render(
+      <CipherSelector
+        ciphers={sampleCiphers}
+        value="alpha"
+        onChange={() => {}}
+        disabled
+      />,
+    );
+
+    expect(screen.getByLabelText("Cifra")).toBeDisabled();
+  });
+});

--- a/components/CipherSelector.test.tsx
+++ b/components/CipherSelector.test.tsx
@@ -78,4 +78,37 @@ describe("CipherSelector", () => {
 
     expect(screen.getByLabelText("Cifra")).toBeDisabled();
   });
+
+  it("gera ids únicos por instância quando selectId não é informado", () => {
+    render(
+      <>
+        <CipherSelector
+          ciphers={sampleCiphers}
+          value="alpha"
+          onChange={() => {}}
+        />
+        <CipherSelector
+          ciphers={sampleCiphers}
+          value="beta"
+          onChange={() => {}}
+        />
+      </>,
+    );
+
+    const [selectA, selectB] = screen.getAllByLabelText("Cifra");
+    expect(selectA.id).not.toBe(selectB.id);
+  });
+
+  it("aceita selectId definido pelo pai", () => {
+    render(
+      <CipherSelector
+        ciphers={sampleCiphers}
+        value="alpha"
+        onChange={() => {}}
+        selectId="cipher-selector"
+      />,
+    );
+
+    expect(screen.getByLabelText("Cifra")).toHaveAttribute("id", "cipher-selector");
+  });
 });

--- a/components/CipherSelector.tsx
+++ b/components/CipherSelector.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import type { CipherMetadata } from "@/types/cipher";
-import type { ChangeEvent } from "react";
+import { useId, type ChangeEvent } from "react";
 
 type CipherSelectorProps = {
   ciphers: readonly CipherMetadata[];
   value: string;
   onChange: (id: string) => void;
   disabled?: boolean;
+  selectId?: string;
 };
 
 export function CipherSelector({
@@ -15,7 +16,10 @@ export function CipherSelector({
   value,
   onChange,
   disabled = false,
+  selectId: selectIdProp,
 }: CipherSelectorProps) {
+  const generatedId = useId();
+  const selectId = selectIdProp ?? generatedId;
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     onChange(event.target.value);
   };
@@ -23,13 +27,13 @@ export function CipherSelector({
   return (
     <div className="flex flex-col gap-2">
       <label
-        htmlFor="cipher-selector"
+        htmlFor={selectId}
         className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
       >
         Cifra
       </label>
       <select
-        id="cipher-selector"
+        id={selectId}
         value={value}
         onChange={handleChange}
         disabled={disabled}

--- a/components/CipherSelector.tsx
+++ b/components/CipherSelector.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { CipherMetadata } from "@/types/cipher";
+import type { ChangeEvent } from "react";
+
+type CipherSelectorProps = {
+  ciphers: readonly CipherMetadata[];
+  value: string;
+  onChange: (id: string) => void;
+  disabled?: boolean;
+};
+
+export function CipherSelector({
+  ciphers,
+  value,
+  onChange,
+  disabled = false,
+}: CipherSelectorProps) {
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label
+        htmlFor="cipher-selector"
+        className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+      >
+        Cifra
+      </label>
+      <select
+        id="cipher-selector"
+        value={value}
+        onChange={handleChange}
+        disabled={disabled}
+        className="w-full rounded-xl border border-zinc-300 bg-white px-3 py-2 text-sm outline-none transition focus-visible:ring-2 focus-visible:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700 dark:bg-zinc-950 dark:focus-visible:ring-zinc-500 sm:max-w-md"
+      >
+        {ciphers.map((cipher) => (
+          <option key={cipher.id} value={cipher.id}>
+            {cipher.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/components/CipherWorkspace.test.tsx
+++ b/components/CipherWorkspace.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { getAllCiphers } from "@/lib/ciphers";
+import { applyCipherSelectionChange } from "./applyCipherSelectionChange";
 import { CipherWorkspace } from "./CipherWorkspace";
 
 describe("CipherWorkspace", () => {
@@ -84,17 +85,23 @@ describe("CipherWorkspace", () => {
     expect(screen.getByLabelText("Resultado")).toHaveValue("ABC DEF");
   });
 
-  it("reseta os parâmetros ao trocar a cifra", () => {
-    render(<CipherWorkspace />);
-
-    const paramsState = screen.getByTestId("cipher-params-state");
-    const ciphers = getAllCiphers();
-    const nextCipher = ciphers[1] ?? ciphers[0];
-
-    fireEvent.change(screen.getByLabelText("Cifra"), {
-      target: { value: nextCipher.id },
+  describe("troca de cifra", () => {
+    it("zera parâmetros previamente preenchidos", () => {
+      expect(
+        applyCipherSelectionChange(
+          { selectedCipherId: "atbash", cipherParams: { shift: 3 } },
+          "caesar",
+        ),
+      ).toEqual({
+        selectedCipherId: "caesar",
+        cipherParams: {},
+      });
     });
 
-    expect(paramsState).toHaveAttribute("data-params", "{}");
+    it("mantém o estado quando a cifra selecionada não muda", () => {
+      const state = { selectedCipherId: "caesar", cipherParams: { shift: 3 } };
+
+      expect(applyCipherSelectionChange(state, "caesar")).toBe(state);
+    });
   });
 });

--- a/components/CipherWorkspace.test.tsx
+++ b/components/CipherWorkspace.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import { getAllCiphers } from "@/lib/ciphers";
 import { CipherWorkspace } from "./CipherWorkspace";
 
 describe("CipherWorkspace", () => {
@@ -54,5 +55,46 @@ describe("CipherWorkspace", () => {
 
     fireEvent.change(input, { target: { value: "   \t" } });
     expect(screen.getByLabelText("Resultado")).toHaveValue("");
+  });
+
+  it("lista todas as cifras do registry no seletor", () => {
+    render(<CipherWorkspace />);
+
+    const expectedNames = getAllCiphers().map((cipher) => cipher.name);
+    const options = screen.getAllByRole("option");
+
+    expect(options).toHaveLength(expectedNames.length);
+    expect(options.map((option) => option.textContent)).toEqual(expectedNames);
+  });
+
+  it("mantém o comportamento mock de Codificar após trocar a cifra", () => {
+    render(<CipherWorkspace />);
+
+    const ciphers = getAllCiphers();
+    const nextCipher = ciphers[1] ?? ciphers[0];
+
+    fireEvent.change(screen.getByLabelText("Cifra"), {
+      target: { value: nextCipher.id },
+    });
+    fireEvent.change(screen.getByLabelText("Texto de entrada"), {
+      target: { value: "abc def" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Codificar" }));
+
+    expect(screen.getByLabelText("Resultado")).toHaveValue("ABC DEF");
+  });
+
+  it("reseta os parâmetros ao trocar a cifra", () => {
+    render(<CipherWorkspace />);
+
+    const paramsState = screen.getByTestId("cipher-params-state");
+    const ciphers = getAllCiphers();
+    const nextCipher = ciphers[1] ?? ciphers[0];
+
+    fireEvent.change(screen.getByLabelText("Cifra"), {
+      target: { value: nextCipher.id },
+    });
+
+    expect(paramsState).toHaveAttribute("data-params", "{}");
   });
 });

--- a/components/CipherWorkspace.tsx
+++ b/components/CipherWorkspace.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CipherSelector } from "@/components/CipherSelector";
+import { applyCipherSelectionChange } from "@/components/applyCipherSelectionChange";
 import { getAllCiphers } from "@/lib/ciphers";
 import { useState, type ChangeEvent } from "react";
 
@@ -26,8 +27,12 @@ export function CipherWorkspace() {
   const isSelectorDisabled = ciphers.length === 0;
 
   const handleCipherChange = (nextId: string) => {
-    setSelectedCipherId(nextId);
-    setCipherParams({});
+    const next = applyCipherSelectionChange(
+      { selectedCipherId, cipherParams },
+      nextId,
+    );
+    setSelectedCipherId(next.selectedCipherId);
+    setCipherParams(next.cipherParams);
   };
 
   const handleEncode = () => {
@@ -54,11 +59,6 @@ export function CipherWorkspace() {
           value={selectedCipherId}
           onChange={handleCipherChange}
           disabled={isSelectorDisabled}
-        />
-        <div
-          data-testid="cipher-params-state"
-          data-params={JSON.stringify(cipherParams)}
-          hidden
         />
       </div>
 

--- a/components/CipherWorkspace.tsx
+++ b/components/CipherWorkspace.tsx
@@ -1,6 +1,10 @@
 "use client";
 
+import { CipherSelector } from "@/components/CipherSelector";
+import { getAllCiphers } from "@/lib/ciphers";
 import { useState, type ChangeEvent } from "react";
+
+const ciphers = getAllCiphers();
 
 function mockEncode(value: string) {
   return value.toUpperCase();
@@ -11,10 +15,20 @@ function mockDecode(value: string) {
 }
 
 export function CipherWorkspace() {
+  const [selectedCipherId, setSelectedCipherId] = useState(
+    () => ciphers[0]?.id ?? "",
+  );
+  const [cipherParams, setCipherParams] = useState<Record<string, unknown>>({});
   const [inputText, setInputText] = useState("");
   const [outputText, setOutputText] = useState("");
 
   const isActionDisabled = inputText.trim().length === 0;
+  const isSelectorDisabled = ciphers.length === 0;
+
+  const handleCipherChange = (nextId: string) => {
+    setSelectedCipherId(nextId);
+    setCipherParams({});
+  };
 
   const handleEncode = () => {
     setOutputText(mockEncode(inputText));
@@ -34,6 +48,20 @@ export function CipherWorkspace() {
 
   return (
     <section className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 sm:p-6">
+      <div className="mb-4 flex flex-col gap-4">
+        <CipherSelector
+          ciphers={ciphers}
+          value={selectedCipherId}
+          onChange={handleCipherChange}
+          disabled={isSelectorDisabled}
+        />
+        <div
+          data-testid="cipher-params-state"
+          data-params={JSON.stringify(cipherParams)}
+          hidden
+        />
+      </div>
+
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <div className="flex flex-col gap-2">
           <label

--- a/components/applyCipherSelectionChange.ts
+++ b/components/applyCipherSelectionChange.ts
@@ -1,0 +1,20 @@
+export type CipherParamsRecord = Record<string, unknown>;
+
+export type CipherWorkspaceSelectionState = {
+  selectedCipherId: string;
+  cipherParams: CipherParamsRecord;
+};
+
+export function applyCipherSelectionChange(
+  state: CipherWorkspaceSelectionState,
+  nextCipherId: string,
+): CipherWorkspaceSelectionState {
+  if (nextCipherId === state.selectedCipherId) {
+    return state;
+  }
+
+  return {
+    selectedCipherId: nextCipherId,
+    cipherParams: {},
+  };
+}


### PR DESCRIPTION
# PR: CV-012 — Seletor de cifra ligado ao registry

## Contexto

Esta PR implementa o seletor de cifra na home conforme a issue **CV-012**, consumindo exclusivamente o `cipherRegistry` via `getAllCiphers()`. O layout base de **CV-011** permanece; a codificação e a decodificação continuam **mock** (maiúsculas/minúsculas) até a integração com `encode`/`decode` reais e o formulário dinâmico de parâmetros (**CV-013**).

## O que foi feito

- **`components/CipherSelector.tsx`** (novo): componente cliente com `<select>` nativo controlado, label “Cifra” associado via `htmlFor`/`id`, opções com `name` visível e `id` como valor interno, estilos alinhados ao workspace (Tailwind, foco visível, suporte a `disabled`).
- **`components/CipherWorkspace.tsx`**: integração do seletor acima do grid entrada/resultado; import único de `getAllCiphers()`; estado `selectedCipherId` (primeira cifra do registry por padrão) e `cipherParams` (`Record<string, unknown>`); reset de `cipherParams` para `{}` ao trocar a cifra; seletor desabilitado se o registry estiver vazio.
- **`components/CipherSelector.test.tsx`** (novo): label associado ao combobox, renderização de opções, valor selecionado, `onChange` e estado desabilitado (lista fake em props, sem duplicar ids do MVP).
- **`components/CipherWorkspace.test.tsx`**: casos existentes preservados; listagem de todas as cifras do registry no seletor; comportamento mock de **Codificar** após troca de cifra; reset de parâmetros ao mudar a seleção.

## Resultado esperado

- A home exibe um seletor com todas as cifras registradas em `lib/ciphers/registry.ts`, na mesma ordem do registry.
- Ao adicionar uma cifra ao registry, ela passa a aparecer no seletor sem lista hardcoded na UI.
- Trocar a cifra não altera o comportamento mock de **Codificar**/**Decodificar** nem o layout responsivo de **CV-011**.
- Não há array paralelo de ids de cifra em `components/` ou `app/`.

## Como validar

1. `npm run dev` e abrir a home (`/`).
2. Confirmar o seletor “Cifra” com as entradas do registry (ex.: Atbash, César, Identity, Morse, Vigenère).
3. Trocar a cifra e verificar que **Codificar**/**Decodificar** seguem o mock (maiúsculas/minúsculas).
4. Com entrada vazia, confirmar que os botões permanecem desabilitados.
5. `npm test`, `npm run lint` e `npm run typecheck`.

## Evidências (opcional no corpo da PR no GitHub)

- Screenshot ou gravação curta do seletor aberto e da troca entre cifras.

## Riscos e impacto

- **Baixo**: alteração concentrada em componentes da home; sem rotas de API nem chamadas a `encode`/`decode` reais.
- O estado `cipherParams` é preparatório para **CV-013**; ainda não há UI de parâmetros.
- Registry vazio desabilita o seletor (cenário improvável no MVP).

## Definition of Done (CV-012)

- [x] Lista sincronizada com o registry na `main`.
- [x] Nenhuma lista duplicada de ids em outro arquivo da UI.
- [x] Reset de parâmetros ao trocar a cifra.
- [ ] Code review Dev A.

## Referências

- Issue: **CV-012** (seletor de cifra ligado ao registry).
- Depende de: **CV-005**, **CV-011**.
- Desbloqueia: **CV-013** (parâmetros por cifra).
- Épico: **E4 — UI/UX**; milestone: **M3 — UI integrada**.
