### PR TITLE
formularios dinamicos

### DIFF
--- a/components/CipherParamsForm.test.tsx
+++ b/components/CipherParamsForm.test.tsx
@@ -58,6 +58,42 @@ describe("CipherParamsForm", () => {
     expect(input).toHaveValue(null);
   });
 
+  it("preserva '-' como estado intermediário para deslocamento negativo", () => {
+    const onParamChange = jest.fn();
+    const paramFields: readonly CipherParamField[] = [
+      {
+        kind: "number",
+        key: "shift",
+        label: "Deslocamento",
+        required: true,
+        integer: true,
+      },
+    ];
+    const { rerender } = render(
+      <CipherParamsForm
+        paramFields={paramFields}
+        value={{ shift: "-" }}
+        onParamChange={onParamChange}
+      />,
+    );
+    const input = screen.getByLabelText(/Deslocamento/) as HTMLInputElement;
+    expect(input.type).toBe("text");
+    expect(input.value).toBe("-");
+
+    fireEvent.change(input, { target: { value: "-3" } });
+    expect(onParamChange).toHaveBeenCalledWith("shift", -3);
+
+    rerender(
+      <CipherParamsForm
+        paramFields={paramFields}
+        value={{ shift: -3 }}
+        onParamChange={onParamChange}
+      />,
+    );
+    expect(input.type).toBe("number");
+    expect(input).toHaveValue(-3);
+  });
+
   it("renderiza campo texto e notifica mudanças", () => {
     const paramFields: readonly CipherParamField[] = [
       {

--- a/components/CipherParamsForm.test.tsx
+++ b/components/CipherParamsForm.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import type { CipherParamField } from "@/types/cipher";
+import { CipherParamsForm } from "./CipherParamsForm";
+
+function NumberFormHarness() {
+  const [value, setValue] = useState<Record<string, unknown>>({});
+  const paramFields: readonly CipherParamField[] = [
+    {
+      kind: "number",
+      key: "shift",
+      label: "Deslocamento",
+      required: true,
+      integer: true,
+    },
+  ];
+  return (
+    <CipherParamsForm
+      paramFields={paramFields}
+      value={value}
+      onParamChange={(key, v) => {
+        setValue((prev) => {
+          const next = { ...prev };
+          if (v === undefined || v === "") {
+            delete next[key];
+          } else {
+            next[key] = v;
+          }
+          return next;
+        });
+      }}
+    />
+  );
+}
+
+describe("CipherParamsForm", () => {
+  it("renderiza bloco help com role note e aria-label", () => {
+    const paramFields: readonly CipherParamField[] = [
+      {
+        kind: "help",
+        key: "h1",
+        label: "Ajuda",
+        description: "Texto de apoio.",
+      },
+    ];
+    render(
+      <CipherParamsForm paramFields={paramFields} value={{}} onParamChange={() => {}} />,
+    );
+    expect(screen.getByRole("note", { name: "Ajuda" })).toHaveTextContent("Texto de apoio.");
+  });
+
+  it("renderiza campo numérico e notifica mudanças", () => {
+    render(<NumberFormHarness />);
+    const input = screen.getByLabelText(/Deslocamento/);
+    fireEvent.change(input, { target: { value: "5" } });
+    expect(input).toHaveValue(5);
+    fireEvent.change(input, { target: { value: "" } });
+    expect(input).toHaveValue(null);
+  });
+
+  it("renderiza campo texto e notifica mudanças", () => {
+    const paramFields: readonly CipherParamField[] = [
+      {
+        kind: "string",
+        key: "key",
+        label: "Palavra-chave",
+        required: true,
+      },
+    ];
+    const onParamChange = jest.fn();
+    render(
+      <CipherParamsForm paramFields={paramFields} value={{}} onParamChange={onParamChange} />,
+    );
+    fireEvent.change(screen.getByLabelText(/Palavra-chave/), {
+      target: { value: "abc" },
+    });
+    expect(onParamChange).toHaveBeenCalledWith("key", "abc");
+  });
+
+  it("exibe erro por campo e erro global", () => {
+    const paramFields: readonly CipherParamField[] = [
+      {
+        kind: "string",
+        key: "key",
+        label: "Chave",
+        required: true,
+      },
+    ];
+    render(
+      <CipherParamsForm
+        paramFields={paramFields}
+        value={{}}
+        onParamChange={() => {}}
+        errors={{ key: "Chave inválida", "*": "Erro geral" }}
+      />,
+    );
+    expect(screen.getByText("Chave inválida")).toBeInTheDocument();
+    expect(screen.getByText("Erro geral")).toBeInTheDocument();
+  });
+
+  it("lista vazia não renderiza campos", () => {
+    const { container } = render(
+      <CipherParamsForm paramFields={[]} value={{}} onParamChange={() => {}} />,
+    );
+    expect(container.querySelector("input")).toBeNull();
+    expect(container.querySelector('[role="note"]')).toBeNull();
+  });
+});

--- a/components/CipherParamsForm.tsx
+++ b/components/CipherParamsForm.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import type { CipherParamField } from "@/types/cipher";
+import { useId } from "react";
+
+export type CipherParamsFormProps = {
+  paramFields: readonly CipherParamField[];
+  value: Record<string, unknown>;
+  onParamChange: (key: string, value: unknown) => void;
+  errors?: Record<string, string>;
+};
+
+const inputClassName =
+  "w-full rounded-xl border border-zinc-300 bg-white px-3 py-2 text-sm outline-none transition focus-visible:ring-2 focus-visible:ring-zinc-400 dark:border-zinc-700 dark:bg-zinc-950 dark:focus-visible:ring-zinc-500 sm:max-w-md";
+
+function inputErrorClass(hasError: boolean): string {
+  return hasError ? " border-red-500 dark:border-red-500" : "";
+}
+
+export function CipherParamsForm({
+  paramFields,
+  value,
+  onParamChange,
+  errors,
+}: CipherParamsFormProps) {
+  const baseId = useId();
+
+  return (
+    <div className="flex flex-col gap-4">
+      {paramFields.map((field) => {
+        if (field.kind === "help") {
+          return (
+            <div
+              key={field.key}
+              className="rounded-xl border border-zinc-200 bg-zinc-50/80 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950/50"
+              role="note"
+              aria-label={field.label}
+            >
+              <p className="font-medium text-zinc-800 dark:text-zinc-200">{field.label}</p>
+              <p className="mt-1 text-zinc-600 dark:text-zinc-400">{field.description}</p>
+            </div>
+          );
+        }
+
+        const fieldId = `${baseId}-${field.key}`;
+        const fieldError = errors?.[field.key];
+
+        if (field.kind === "number") {
+          const raw = value[field.key];
+          const display =
+            raw === undefined || raw === null
+              ? ""
+              : typeof raw === "number" && Number.isFinite(raw)
+                ? String(raw)
+                : String(raw);
+          const describedBy =
+            field.description !== undefined ? `${fieldId}-desc` : undefined;
+
+          return (
+            <div key={field.key} className="flex flex-col gap-1">
+              <label
+                htmlFor={fieldId}
+                className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
+                {field.label}
+                {field.required ? (
+                  <span className="text-red-600 dark:text-red-400"> *</span>
+                ) : null}
+              </label>
+              {field.description !== undefined ? (
+                <p id={`${fieldId}-desc`} className="text-xs text-zinc-500 dark:text-zinc-400">
+                  {field.description}
+                </p>
+              ) : null}
+              <input
+                id={fieldId}
+                type="number"
+                aria-invalid={Boolean(fieldError)}
+                aria-describedby={describedBy}
+                required={field.required}
+                min={field.min}
+                max={field.max}
+                step={field.integer === false ? "any" : "1"}
+                value={display}
+                onChange={(event) => {
+                  const s = event.target.value;
+                  if (s === "" || s === "-") {
+                    onParamChange(field.key, undefined);
+                    return;
+                  }
+                  const n = Number(s);
+                  if (!Number.isFinite(n)) {
+                    onParamChange(field.key, undefined);
+                    return;
+                  }
+                  onParamChange(field.key, n);
+                }}
+                className={inputClassName + inputErrorClass(Boolean(fieldError))}
+              />
+              {fieldError !== undefined ? (
+                <p className="text-xs text-red-600 dark:text-red-400" role="alert">
+                  {fieldError}
+                </p>
+              ) : null}
+            </div>
+          );
+        }
+
+        const strVal = value[field.key];
+        const strDisplay =
+          strVal === undefined || strVal === null ? "" : String(strVal);
+        const strDescribedBy =
+          field.description !== undefined ? `${fieldId}-desc-str` : undefined;
+
+        return (
+          <div key={field.key} className="flex flex-col gap-1">
+            <label
+              htmlFor={fieldId}
+              className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+            >
+              {field.label}
+              {field.required ? (
+                <span className="text-red-600 dark:text-red-400"> *</span>
+              ) : null}
+            </label>
+            {field.description !== undefined ? (
+              <p id={`${fieldId}-desc-str`} className="text-xs text-zinc-500 dark:text-zinc-400">
+                {field.description}
+              </p>
+            ) : null}
+            <input
+              id={fieldId}
+              type="text"
+              aria-invalid={Boolean(fieldError)}
+              aria-describedby={strDescribedBy}
+              required={field.required}
+              maxLength={field.maxLength}
+              value={strDisplay}
+              onChange={(event) => {
+                const v = event.target.value;
+                onParamChange(field.key, v === "" ? undefined : v);
+              }}
+              className={inputClassName + inputErrorClass(Boolean(fieldError))}
+            />
+            {fieldError !== undefined ? (
+              <p className="text-xs text-red-600 dark:text-red-400" role="alert">
+                {fieldError}
+              </p>
+            ) : null}
+          </div>
+        );
+      })}
+      {errors?.["*"] !== undefined ? (
+        <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+          {errors["*"]}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/CipherParamsForm.tsx
+++ b/components/CipherParamsForm.tsx
@@ -17,6 +17,12 @@ function inputErrorClass(hasError: boolean): string {
   return hasError ? " border-red-500 dark:border-red-500" : "";
 }
 
+/** Lista ids para `aria-describedby` (descrição + erro); omitir atributo se vazio. */
+function ariaDescribedByIds(...ids: (string | undefined)[]): string | undefined {
+  const parts = ids.filter((id): id is string => id !== undefined && id.length > 0);
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
 export function CipherParamsForm({
   paramFields,
   value,
@@ -47,14 +53,17 @@ export function CipherParamsForm({
 
         if (field.kind === "number") {
           const raw = value[field.key];
+          const isDraftString = typeof raw === "string";
           const display =
             raw === undefined || raw === null
               ? ""
               : typeof raw === "number" && Number.isFinite(raw)
                 ? String(raw)
                 : String(raw);
-          const describedBy =
-            field.description !== undefined ? `${fieldId}-desc` : undefined;
+          const describedBy = ariaDescribedByIds(
+            field.description !== undefined ? `${fieldId}-desc` : undefined,
+            fieldError !== undefined ? `${fieldId}-err` : undefined,
+          );
 
           return (
             <div key={field.key} className="flex flex-col gap-1">
@@ -74,31 +83,38 @@ export function CipherParamsForm({
               ) : null}
               <input
                 id={fieldId}
-                type="number"
+                type={isDraftString ? "text" : "number"}
+                inputMode={
+                  isDraftString ? (field.integer === false ? "decimal" : "numeric") : undefined
+                }
                 aria-invalid={Boolean(fieldError)}
                 aria-describedby={describedBy}
                 required={field.required}
-                min={field.min}
-                max={field.max}
-                step={field.integer === false ? "any" : "1"}
+                min={isDraftString ? undefined : field.min}
+                max={isDraftString ? undefined : field.max}
+                step={isDraftString ? undefined : field.integer === false ? "any" : "1"}
                 value={display}
                 onChange={(event) => {
                   const s = event.target.value;
-                  if (s === "" || s === "-") {
+                  if (s === "") {
                     onParamChange(field.key, undefined);
                     return;
                   }
                   const n = Number(s);
-                  if (!Number.isFinite(n)) {
-                    onParamChange(field.key, undefined);
+                  if (Number.isFinite(n)) {
+                    onParamChange(field.key, n);
                     return;
                   }
-                  onParamChange(field.key, n);
+                  onParamChange(field.key, s);
                 }}
                 className={inputClassName + inputErrorClass(Boolean(fieldError))}
               />
               {fieldError !== undefined ? (
-                <p className="text-xs text-red-600 dark:text-red-400" role="alert">
+                <p
+                  id={`${fieldId}-err`}
+                  className="text-xs text-red-600 dark:text-red-400"
+                  role="alert"
+                >
                   {fieldError}
                 </p>
               ) : null}
@@ -109,8 +125,10 @@ export function CipherParamsForm({
         const strVal = value[field.key];
         const strDisplay =
           strVal === undefined || strVal === null ? "" : String(strVal);
-        const strDescribedBy =
-          field.description !== undefined ? `${fieldId}-desc-str` : undefined;
+        const strDescribedBy = ariaDescribedByIds(
+          field.description !== undefined ? `${fieldId}-desc-str` : undefined,
+          fieldError !== undefined ? `${fieldId}-err` : undefined,
+        );
 
         return (
           <div key={field.key} className="flex flex-col gap-1">
@@ -143,7 +161,11 @@ export function CipherParamsForm({
               className={inputClassName + inputErrorClass(Boolean(fieldError))}
             />
             {fieldError !== undefined ? (
-              <p className="text-xs text-red-600 dark:text-red-400" role="alert">
+              <p
+                id={`${fieldId}-err`}
+                className="text-xs text-red-600 dark:text-red-400"
+                role="alert"
+              >
                 {fieldError}
               </p>
             ) : null}

--- a/components/CipherWorkspace.test.tsx
+++ b/components/CipherWorkspace.test.tsx
@@ -72,7 +72,8 @@ describe("CipherWorkspace", () => {
     render(<CipherWorkspace />);
 
     const ciphers = getAllCiphers();
-    const nextCipher = ciphers[1] ?? ciphers[0];
+    const nextCipher =
+      ciphers.find((c) => c.id === "identity") ?? ciphers.find((c) => c.id === "morse") ?? ciphers[0];
 
     fireEvent.change(screen.getByLabelText("Cifra"), {
       target: { value: nextCipher.id },
@@ -103,5 +104,42 @@ describe("CipherWorkspace", () => {
 
       expect(applyCipherSelectionChange(state, "caesar")).toBe(state);
     });
+  });
+
+  it("exibe texto de ajuda da cifra Atbash (primeira do registry) como nota", () => {
+    render(<CipherWorkspace />);
+    const first = getAllCiphers()[0];
+    expect(first?.id).toBe("atbash");
+    expect(screen.getByRole("note", { name: "Parâmetros" })).toBeInTheDocument();
+  });
+
+  it("exige deslocamento na César antes de habilitar Codificar com texto", () => {
+    render(<CipherWorkspace />);
+
+    fireEvent.change(screen.getByLabelText("Cifra"), { target: { value: "caesar" } });
+    fireEvent.change(screen.getByLabelText("Texto de entrada"), {
+      target: { value: "abc" },
+    });
+
+    expect(screen.getByRole("button", { name: "Codificar" })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Deslocamento/), { target: { value: "1" } });
+    expect(screen.getByRole("button", { name: "Codificar" })).not.toBeDisabled();
+  });
+
+  it("após trocar de César para Vigenère, parâmetros são limpos e palavra-chave volta a ser obrigatória", () => {
+    render(<CipherWorkspace />);
+
+    fireEvent.change(screen.getByLabelText("Cifra"), { target: { value: "caesar" } });
+    fireEvent.change(screen.getByLabelText(/Deslocamento/), { target: { value: "3" } });
+    fireEvent.change(screen.getByLabelText("Texto de entrada"), {
+      target: { value: "abc" },
+    });
+    expect(screen.getByRole("button", { name: "Codificar" })).not.toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Cifra"), { target: { value: "vigenere" } });
+    expect(screen.queryByLabelText(/Deslocamento/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/Palavra-chave/)).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Codificar" })).toBeDisabled();
   });
 });

--- a/components/CipherWorkspace.tsx
+++ b/components/CipherWorkspace.tsx
@@ -1,9 +1,15 @@
 "use client";
 
+import { CipherParamsForm } from "@/components/CipherParamsForm";
 import { CipherSelector } from "@/components/CipherSelector";
 import { applyCipherSelectionChange } from "@/components/applyCipherSelectionChange";
-import { getAllCiphers } from "@/lib/ciphers";
-import { useState, type ChangeEvent } from "react";
+import { getAllCiphers, getCipherById } from "@/lib/ciphers";
+import {
+  isCipherValidationError,
+  type CipherDefinition,
+  type CipherParamsParseResult,
+} from "@/types/cipher";
+import { useMemo, useState, type ChangeEvent } from "react";
 
 const ciphers = getAllCiphers();
 
@@ -15,6 +21,34 @@ function mockDecode(value: string) {
   return value.toLowerCase();
 }
 
+function tryParseCipherParams(
+  definition: CipherDefinition<unknown> | undefined,
+  raw: Record<string, unknown>,
+): { ok: true } | { ok: false; errors: Record<string, string> } {
+  if (!definition?.parseParams) {
+    return { ok: true };
+  }
+  try {
+    const out = definition.parseParams(raw);
+    if (out !== null && typeof out === "object" && "ok" in out) {
+      const r = out as CipherParamsParseResult<unknown>;
+      if (!r.ok) {
+        const e = r.error;
+        const field = e.field ?? "*";
+        return { ok: false, errors: { [field]: e.message } };
+      }
+      return { ok: true };
+    }
+    return { ok: true };
+  } catch (e) {
+    if (isCipherValidationError(e)) {
+      const field = e.field ?? "*";
+      return { ok: false, errors: { [field]: e.message } };
+    }
+    throw e;
+  }
+}
+
 export function CipherWorkspace() {
   const [selectedCipherId, setSelectedCipherId] = useState(
     () => ciphers[0]?.id ?? "",
@@ -23,8 +57,21 @@ export function CipherWorkspace() {
   const [inputText, setInputText] = useState("");
   const [outputText, setOutputText] = useState("");
 
-  const isActionDisabled = inputText.trim().length === 0;
   const isSelectorDisabled = ciphers.length === 0;
+
+  const selectedDefinition = useMemo(
+    () => getCipherById(selectedCipherId),
+    [selectedCipherId],
+  );
+
+  const { isParamsValid, paramErrors } = useMemo(() => {
+    const result = tryParseCipherParams(selectedDefinition, cipherParams);
+    return result.ok
+      ? { isParamsValid: true as const, paramErrors: undefined }
+      : { isParamsValid: false as const, paramErrors: result.errors };
+  }, [selectedDefinition, cipherParams]);
+
+  const isActionDisabled = inputText.trim().length === 0 || !isParamsValid;
 
   const handleCipherChange = (nextId: string) => {
     const next = applyCipherSelectionChange(
@@ -33,6 +80,18 @@ export function CipherWorkspace() {
     );
     setSelectedCipherId(next.selectedCipherId);
     setCipherParams(next.cipherParams);
+  };
+
+  const handleParamChange = (key: string, value: unknown) => {
+    setCipherParams((prev) => {
+      const next = { ...prev };
+      if (value === undefined || value === "") {
+        delete next[key];
+      } else {
+        next[key] = value;
+      }
+      return next;
+    });
   };
 
   const handleEncode = () => {
@@ -51,6 +110,8 @@ export function CipherWorkspace() {
     }
   };
 
+  const paramFields = selectedDefinition?.paramFields ?? [];
+
   return (
     <section className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 sm:p-6">
       <div className="mb-4 flex flex-col gap-4">
@@ -60,6 +121,14 @@ export function CipherWorkspace() {
           onChange={handleCipherChange}
           disabled={isSelectorDisabled}
         />
+        {paramFields.length > 0 ? (
+          <CipherParamsForm
+            paramFields={paramFields}
+            value={cipherParams}
+            onParamChange={handleParamChange}
+            errors={paramErrors}
+          />
+        ) : null}
       </div>
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">

--- a/components/CipherWorkspace.tsx
+++ b/components/CipherWorkspace.tsx
@@ -5,9 +5,9 @@ import { CipherSelector } from "@/components/CipherSelector";
 import { applyCipherSelectionChange } from "@/components/applyCipherSelectionChange";
 import { getAllCiphers, getCipherById } from "@/lib/ciphers";
 import {
+  isCipherParamsParseResult,
   isCipherValidationError,
   type CipherDefinition,
-  type CipherParamsParseResult,
 } from "@/types/cipher";
 import { useMemo, useState, type ChangeEvent } from "react";
 
@@ -30,10 +30,9 @@ function tryParseCipherParams(
   }
   try {
     const out = definition.parseParams(raw);
-    if (out !== null && typeof out === "object" && "ok" in out) {
-      const r = out as CipherParamsParseResult<unknown>;
-      if (!r.ok) {
-        const e = r.error;
+    if (isCipherParamsParseResult(out)) {
+      if (!out.ok) {
+        const e = out.error;
         const field = e.field ?? "*";
         return { ok: false, errors: { [field]: e.message } };
       }

--- a/lib/ciphers/atbash.ts
+++ b/lib/ciphers/atbash.ts
@@ -44,7 +44,15 @@ function transform(text: string): string {
 export const atbashCipher = {
   id: "atbash",
   name: "Atbash",
-  paramFields: [],
+  paramFields: [
+    {
+      kind: "help",
+      key: "atbash-info",
+      label: "Parâmetros",
+      description:
+        "Esta cifra não usa parâmetros. Apenas letras latinas A–Z e a–z são espelhadas; demais caracteres permanecem iguais. Codificar e decodificar são a mesma operação.",
+    },
+  ],
   encode: (plainText, params) => {
     void params;
     return transform(plainText);

--- a/lib/ciphers/caesar.ts
+++ b/lib/ciphers/caesar.ts
@@ -72,8 +72,8 @@ export const caesarCipher = {
     {
       kind: "number",
       key: "shift",
-      label: "Shift",
-      description: "Integer rotation for Latin letters A–Z and a–z.",
+      label: "Deslocamento",
+      description: "Rotação inteira para letras latinas A–Z e a–z; demais caracteres são preservados.",
       required: true,
       integer: true,
     },

--- a/lib/ciphers/morse.ts
+++ b/lib/ciphers/morse.ts
@@ -207,7 +207,15 @@ export function decodeMorse(cipherText: string): string {
 export const morseCipher = {
   id: "morse",
   name: "Morse",
-  paramFields: [],
+  paramFields: [
+    {
+      kind: "help",
+      key: "morse-separators",
+      label: "Separadores na decodificação",
+      description:
+        "Na saída codificada, letras da mesma palavra são separadas por um espaço; palavras diferentes por \" / \". Na decodificação, \"/\" marca fim de palavra; dois ou mais espaços ou quebras de linha/tab também separam palavras; um único espaço entre símbolos . e - pertence ao mesmo caractere.",
+    },
+  ],
   encode: (plainText, params) => {
     void params;
     return encodeMorse(plainText);

--- a/lib/ciphers/vigenere.ts
+++ b/lib/ciphers/vigenere.ts
@@ -105,8 +105,8 @@ export const vigenereCipher = {
     {
       kind: "string",
       key: "key",
-      label: "Key",
-      description: "Alphabetic keyword (A–Z). Case-insensitive.",
+      label: "Palavra-chave",
+      description: "Apenas letras A–Z (maiúsculas ou minúsculas).",
       required: true,
       minLength: 1,
       pattern: "^[A-Za-z]+$",

--- a/types/cipher.ts
+++ b/types/cipher.ts
@@ -7,7 +7,8 @@
  * - `name`: rótulo curto para UI.
  * - `paramFields`: descrição **em runtime** dos campos de parâmetro para formulário
  *   dinâmico (CV-013). Deve refletir o tipo `P` (ex.: campo `shift` quando
- *   `P` é `{ shift: number }`). Cifras sem parâmetros usam array vazio.
+ *   `P` é `{ shift: number }`). Cifras sem parâmetros editáveis usam array vazio ou
+ *   apenas entradas `kind: "help"` (texto informativo, fora de `parseParams`).
  * - `encode(plainText, params)` / `decode(cipherText, params)`: funções puras;
  *   o mesmo `params` é usado nos dois sentidos.
  *
@@ -64,7 +65,15 @@ export type CipherParamFieldString = CipherParamFieldBase & {
   readonly pattern?: string;
 };
 
-export type CipherParamField = CipherParamFieldNumber | CipherParamFieldString;
+/** Texto só de leitura no formulário; não participa de `cipherParams` nem de `parseParams`. */
+export type CipherParamFieldHelp = {
+  readonly kind: "help";
+  readonly key: string;
+  readonly label: string;
+  readonly description: string;
+};
+
+export type CipherParamField = CipherParamFieldNumber | CipherParamFieldString | CipherParamFieldHelp;
 
 // --- Erros de validação previsíveis ---
 

--- a/types/cipher.ts
+++ b/types/cipher.ts
@@ -108,6 +108,26 @@ export type CipherParamsParseResult<P> =
   | { readonly ok: true; readonly value: P }
   | { readonly ok: false; readonly error: CipherValidationError };
 
+/**
+ * Estreita o retorno de `parseParams` para {@link CipherParamsParseResult}
+ * sem `as`: discrimina por `ok` e valida `value` / instância de {@link CipherValidationError}.
+ */
+export function isCipherParamsParseResult<P = unknown>(
+  value: unknown,
+): value is CipherParamsParseResult<P> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const okTag = Reflect.get(value, "ok");
+  if (okTag === true) {
+    return Reflect.has(value, "value");
+  }
+  if (okTag === false) {
+    return isCipherValidationError(Reflect.get(value, "error"));
+  }
+  return false;
+}
+
 // --- Definição de cifra ---
 
 export type CipherDefinition<P = EmptyCipherParams> = {


### PR DESCRIPTION
# PR: CV-013 — Formulário dinâmico de parâmetros

## Contexto

Esta PR implementa a issue **CV-013** (formulário de parâmetros por cifra), sobre a base de **CV-012** (seletor ligado ao registry e estado `cipherParams`). Os campos são **dirigidos por `paramFields`** do contrato **CV-004**, sem lista paralela de ids na UI. A definição da cifra selecionada vem de `getCipherById(selectedCipherId)` em complemento a `getAllCiphers()`.

**Codificar** e **Decodificar** continuam usando o **mock** (maiúsculas / minúsculas) do CV-012; esta PR foca em **UX de parâmetros**, validação alinhada a `parseParams` e mensagens de erro. A ligação a `encode` / `decode` reais pode ser uma PR de integração separada.

## O que foi feito

### Contrato e lib

- **`types/cipher.ts`**: novo variant **`CipherParamFieldHelp`** (`kind: "help"`) para texto só de leitura no formulário, fora de `cipherParams` e de `parseParams`; union `CipherParamField` atualizada; documentação ajustada.
- **`lib/ciphers/atbash.ts`**: `paramFields` com bloco `help` em português (sem parâmetros editáveis; escopo da cifra).
- **`lib/ciphers/morse.ts`**: `paramFields` com `help` explicando separadores na codificação/decodificação (`/`, espaços, etc.).
- **`lib/ciphers/caesar.ts`** e **`lib/ciphers/vigenere.ts`**: rótulos e descrições dos campos em **português** (“Deslocamento”, “Palavra-chave”).

### UI

- **`components/CipherParamsForm.tsx`** (novo): renderiza `number`, `string` e `help`; `value` / `onParamChange` por chave; exibição de erros por campo e erro global (`*`); estilos alinhados ao workspace (Tailwind, dark mode, foco visível).
- **`components/CipherWorkspace.tsx`**: `getCipherById` + validação com `tryParseCipherParams` (suporta `parseParams` que lança `CipherValidationError` ou retorna `CipherParamsParseResult`); **Codificar** / **Decodificar** desabilitados se a entrada estiver vazia (após trim) **ou** se os parâmetros forem inválidos; `CipherParamsForm` abaixo do seletor; o bloco de parâmetros **não é renderizado** quando `paramFields` está vazio (ex.: Identity).

### Testes

- **`components/CipherParamsForm.test.tsx`** (novo): help, número (harness controlado), string, erros, lista vazia.
- **`components/CipherWorkspace.test.tsx`**: nota de ajuda da Atbash (primeira cifra do registry); César exige deslocamento para habilitar ações; troca César → Vigenère zera parâmetros e exige palavra-chave; teste de mock após troca de cifra usa **Identity** (cifra sem parâmetros), pois César exigiria `shift` preenchido.

## Resultado esperado

- Ao trocar a cifra, os campos (ou o bloco de ajuda) refletem `paramFields` do registry.
- César e Vigenère exibem campos corretos com validação coerente com o core; botões permanecem desabilitados até parâmetros válidos e texto não vazio.
- Atbash e Morse exibem texto de ajuda sem inputs extras; Identity não exibe formulário de parâmetros.
- Nenhuma lista duplicada de ids de cifra na UI.

## Como validar

1. `npm run dev` e abrir a home (`/`).
2. Percorrer cifras no seletor e conferir campos / ajuda conforme a cifra.
3. Na César, deixar deslocamento vazio com texto na entrada: **Codificar** / **Decodificar** desabilitados; preencher um inteiro válido e confirmar que os botões habilitam e o resultado segue o **mock** (maiúsculas / minúsculas).
4. `npm test`, `npm run lint` e `npm run typecheck`.

## Evidências (opcional no corpo da PR no GitHub)

- Captura do formulário na César, na Vigenère e do bloco de ajuda na Morse.

## Riscos e impacto

- **Baixo a moderado**: mudança em `types/cipher.ts` (novo `kind`) e em `paramFields` de cifras públicas; consumidores do tipo `CipherParamField` precisam tratar `kind: "help"` se iterarem o union (esta PR já cobre a UI).
- **Contrato**: alinhar com Dev A se houver política estrita sobre extensões do union sem RFC formal.

## Definition of Done (CV-013)

- [x] Quatro cifras do MVP com UX de parâmetros / ajuda adequada (César, Vigenère, Atbash, Morse; Identity sem campos).
- [x] Tipos alinhados com `lib/` / `types/` sem casts inseguros desnecessários na nova UI.
- [ ] Revisão conjunta Dev A + Dev B se houver dúvida de contrato.

## Referências

- Issue: **CV-013** (formulário dinâmico de parâmetros); origem: `task-formulario-dinamico.md` / planejamento **CV-013**.
- Depende de: **CV-004** (schema), **CV-005**, **CV-012**.
- Relacionado: **CV-014** (validação mais rica no cliente, se existir no roadmap).
- Épico: **E4 — UI/UX**; milestone: **M3 — UI integrada**.

Prints:

<img width="1202" height="669" alt="image" src="https://github.com/user-attachments/assets/2b5bbbfa-c4a3-4985-9a76-f0cb56af3e2a" />

<img width="1236" height="669" alt="image" src="https://github.com/user-attachments/assets/64bf4747-434c-43f2-808f-cb5483b67309" />

<img width="1194" height="671" alt="image" src="https://github.com/user-attachments/assets/4e4b252e-5312-44c4-8318-6ca6eceef9ba" />

<img width="1215" height="661" alt="image" src="https://github.com/user-attachments/assets/ece42c6e-8e19-4a29-a0ed-f3d3533ea578" />
