### PR TITLE
validação

### DIFF
--- a/components/CipherWorkspace.test.tsx
+++ b/components/CipherWorkspace.test.tsx
@@ -1,5 +1,15 @@
+/**
+ * Checklist manual CV-014 (colar na descrição da PR):
+ * - Entrada vazia ou só espaços: botões desativados, sem erro de transformação.
+ * - César sem deslocamento com texto: botões desativados.
+ * - César com deslocamento não inteiro ou inválido: mensagem de erro no campo (PT).
+ * - Vigenère com chave vazia ou com dígitos/símbolos: mensagem no campo (PT).
+ * - Morse: decodificar "..-.-" mostra alerta com trecho problemático em PT.
+ * - Após erro de transformação, trocar de cifra ou editar entrada/params: alerta some.
+ * - Happy path: Atbash com "abc", César com shift 1, Morse roundtrip "SOS".
+ */
 import { render, screen, fireEvent } from "@testing-library/react";
-import { getAllCiphers } from "@/lib/ciphers";
+import { getAllCiphers, getCiphersForSelector } from "@/lib/ciphers";
 import { applyCipherSelectionChange } from "./applyCipherSelectionChange";
 import { CipherWorkspace } from "./CipherWorkspace";
 
@@ -26,22 +36,23 @@ describe("CipherWorkspace", () => {
     expect(screen.getByRole("button", { name: "Decodificar" })).toBeDisabled();
   });
 
-  it("Codificar coloca o resultado em maiúsculas", () => {
+  it("Codificar aplica a cifra Atbash (primeira do registry)", () => {
     render(<CipherWorkspace />);
+    expect(getAllCiphers()[0]?.id).toBe("atbash");
     fireEvent.change(screen.getByLabelText("Texto de entrada"), {
       target: { value: "abc def" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Codificar" }));
-    expect(screen.getByLabelText("Resultado")).toHaveValue("ABC DEF");
+    expect(screen.getByLabelText("Resultado")).toHaveValue("zyx wvu");
   });
 
-  it("Decodificar coloca o resultado em minúsculas", () => {
+  it("Decodificar aplica Atbash (mesma operação que codificar)", () => {
     render(<CipherWorkspace />);
     fireEvent.change(screen.getByLabelText("Texto de entrada"), {
       target: { value: "ABC DEF" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Decodificar" }));
-    expect(screen.getByLabelText("Resultado")).toHaveValue("abc def");
+    expect(screen.getByLabelText("Resultado")).toHaveValue("ZYX WVU");
   });
 
   it("limpa o resultado quando a entrada fica vazia ou só com espaços após trim", () => {
@@ -49,7 +60,7 @@ describe("CipherWorkspace", () => {
     const input = screen.getByLabelText("Texto de entrada");
     fireEvent.change(input, { target: { value: "hi" } });
     fireEvent.click(screen.getByRole("button", { name: "Codificar" }));
-    expect(screen.getByLabelText("Resultado")).toHaveValue("HI");
+    expect(screen.getByLabelText("Resultado")).toHaveValue("sr");
 
     fireEvent.change(input, { target: { value: "" } });
     expect(screen.getByLabelText("Resultado")).toHaveValue("");
@@ -58,32 +69,47 @@ describe("CipherWorkspace", () => {
     expect(screen.getByLabelText("Resultado")).toHaveValue("");
   });
 
-  it("lista todas as cifras do registry no seletor", () => {
+  it("lista no seletor só cifras visíveis (sem Identity; Identity permanece no registry)", () => {
     render(<CipherWorkspace />);
 
-    const expectedNames = getAllCiphers().map((cipher) => cipher.name);
+    expect(getAllCiphers().some((c) => c.id === "identity")).toBe(true);
+    expect(getCiphersForSelector().some((c) => c.id === "identity")).toBe(false);
+
+    const expectedNames = getCiphersForSelector().map((cipher) => cipher.name);
     const options = screen.getAllByRole("option");
 
     expect(options).toHaveLength(expectedNames.length);
     expect(options.map((option) => option.textContent)).toEqual(expectedNames);
+    expect(screen.queryByRole("option", { name: "Identity" })).not.toBeInTheDocument();
   });
 
-  it("mantém o comportamento mock de Codificar após trocar a cifra", () => {
+  it("exibe erro em português ao decodificar Morse inválido", () => {
     render(<CipherWorkspace />);
 
-    const ciphers = getAllCiphers();
-    const nextCipher =
-      ciphers.find((c) => c.id === "identity") ?? ciphers.find((c) => c.id === "morse") ?? ciphers[0];
-
-    fireEvent.change(screen.getByLabelText("Cifra"), {
-      target: { value: nextCipher.id },
-    });
+    fireEvent.change(screen.getByLabelText("Cifra"), { target: { value: "morse" } });
     fireEvent.change(screen.getByLabelText("Texto de entrada"), {
-      target: { value: "abc def" },
+      target: { value: "..-.-" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Codificar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Decodificar" }));
 
-    expect(screen.getByLabelText("Resultado")).toHaveValue("ABC DEF");
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toMatch(/interpretada/i);
+    expect(alert.textContent).toContain("..-.-");
+    expect(screen.getByLabelText("Resultado")).toHaveValue("");
+  });
+
+  it("remove o alerta de transformação ao trocar de cifra", () => {
+    render(<CipherWorkspace />);
+
+    fireEvent.change(screen.getByLabelText("Cifra"), { target: { value: "morse" } });
+    fireEvent.change(screen.getByLabelText("Texto de entrada"), {
+      target: { value: "..-.-" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Decodificar" }));
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Cifra"), { target: { value: "atbash" } });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   describe("troca de cifra", () => {

--- a/components/CipherWorkspace.tsx
+++ b/components/CipherWorkspace.tsx
@@ -3,71 +3,43 @@
 import { CipherParamsForm } from "@/components/CipherParamsForm";
 import { CipherSelector } from "@/components/CipherSelector";
 import { applyCipherSelectionChange } from "@/components/applyCipherSelectionChange";
-import { getAllCiphers, getCipherById } from "@/lib/ciphers";
-import {
-  isCipherParamsParseResult,
-  isCipherValidationError,
-  type CipherDefinition,
-} from "@/types/cipher";
+import { getCipherById, getCiphersForSelector } from "@/lib/ciphers";
+import { formatCipherError } from "@/lib/formatCipherError";
+import { tryParseCipherParams } from "@/lib/tryParseCipherParams";
 import { useMemo, useState, type ChangeEvent } from "react";
 
-const ciphers = getAllCiphers();
-
-function mockEncode(value: string) {
-  return value.toUpperCase();
-}
-
-function mockDecode(value: string) {
-  return value.toLowerCase();
-}
-
-function tryParseCipherParams(
-  definition: CipherDefinition<unknown> | undefined,
-  raw: Record<string, unknown>,
-): { ok: true } | { ok: false; errors: Record<string, string> } {
-  if (!definition?.parseParams) {
-    return { ok: true };
-  }
-  try {
-    const out = definition.parseParams(raw);
-    if (isCipherParamsParseResult(out)) {
-      if (!out.ok) {
-        const e = out.error;
-        const field = e.field ?? "*";
-        return { ok: false, errors: { [field]: e.message } };
-      }
-      return { ok: true };
-    }
-    return { ok: true };
-  } catch (e) {
-    if (isCipherValidationError(e)) {
-      const field = e.field ?? "*";
-      return { ok: false, errors: { [field]: e.message } };
-    }
-    throw e;
-  }
-}
+const selectorCiphers = getCiphersForSelector();
 
 export function CipherWorkspace() {
   const [selectedCipherId, setSelectedCipherId] = useState(
-    () => ciphers[0]?.id ?? "",
+    () => selectorCiphers[0]?.id ?? "",
   );
   const [cipherParams, setCipherParams] = useState<Record<string, unknown>>({});
   const [inputText, setInputText] = useState("");
   const [outputText, setOutputText] = useState("");
+  const [transformError, setTransformError] = useState<string | undefined>();
 
-  const isSelectorDisabled = ciphers.length === 0;
+  const isSelectorDisabled = selectorCiphers.length === 0;
 
   const selectedDefinition = useMemo(
     () => getCipherById(selectedCipherId),
     [selectedCipherId],
   );
 
-  const { isParamsValid, paramErrors } = useMemo(() => {
+  const { isParamsValid, paramErrors, parsedParams } = useMemo(() => {
     const result = tryParseCipherParams(selectedDefinition, cipherParams);
-    return result.ok
-      ? { isParamsValid: true as const, paramErrors: undefined }
-      : { isParamsValid: false as const, paramErrors: result.errors };
+    if (!result.ok) {
+      return {
+        isParamsValid: false as const,
+        paramErrors: result.errors,
+        parsedParams: undefined,
+      };
+    }
+    return {
+      isParamsValid: true as const,
+      paramErrors: undefined,
+      parsedParams: result.params,
+    };
   }, [selectedDefinition, cipherParams]);
 
   const isActionDisabled = inputText.trim().length === 0 || !isParamsValid;
@@ -79,6 +51,7 @@ export function CipherWorkspace() {
     );
     setSelectedCipherId(next.selectedCipherId);
     setCipherParams(next.cipherParams);
+    setTransformError(undefined);
   };
 
   const handleParamChange = (key: string, value: unknown) => {
@@ -91,19 +64,37 @@ export function CipherWorkspace() {
       }
       return next;
     });
+    setTransformError(undefined);
   };
 
-  const handleEncode = () => {
-    setOutputText(mockEncode(inputText));
+  const runEncode = () => {
+    if (!selectedDefinition) return;
+    setTransformError(undefined);
+    try {
+      const out = selectedDefinition.encode(inputText, parsedParams);
+      setOutputText(out);
+    } catch (e) {
+      setOutputText("");
+      setTransformError(formatCipherError(e));
+    }
   };
 
-  const handleDecode = () => {
-    setOutputText(mockDecode(inputText));
+  const runDecode = () => {
+    if (!selectedDefinition) return;
+    setTransformError(undefined);
+    try {
+      const out = selectedDefinition.decode(inputText, parsedParams);
+      setOutputText(out);
+    } catch (e) {
+      setOutputText("");
+      setTransformError(formatCipherError(e));
+    }
   };
 
   const handleInputChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const next = event.target.value;
     setInputText(next);
+    setTransformError(undefined);
     if (next.trim().length === 0) {
       setOutputText("");
     }
@@ -115,7 +106,7 @@ export function CipherWorkspace() {
     <section className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 sm:p-6">
       <div className="mb-4 flex flex-col gap-4">
         <CipherSelector
-          ciphers={ciphers}
+          ciphers={selectorCiphers}
           value={selectedCipherId}
           onChange={handleCipherChange}
           disabled={isSelectorDisabled}
@@ -129,6 +120,16 @@ export function CipherWorkspace() {
           />
         ) : null}
       </div>
+
+      {transformError !== undefined ? (
+        <p
+          className="mb-4 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-200"
+          role="alert"
+          aria-live="assertive"
+        >
+          {transformError}
+        </p>
+      ) : null}
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <div className="flex flex-col gap-2">
@@ -169,7 +170,7 @@ export function CipherWorkspace() {
       <div className="mt-4 flex flex-col gap-3 sm:flex-row">
         <button
           type="button"
-          onClick={handleEncode}
+          onClick={runEncode}
           disabled={isActionDisabled}
           className="inline-flex w-full items-center justify-center rounded-xl bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300 sm:w-auto"
         >
@@ -177,7 +178,7 @@ export function CipherWorkspace() {
         </button>
         <button
           type="button"
-          onClick={handleDecode}
+          onClick={runDecode}
           disabled={isActionDisabled}
           className="inline-flex w-full items-center justify-center rounded-xl border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-900 transition hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 sm:w-auto"
         >

--- a/components/CipherWorkspace.tsx
+++ b/components/CipherWorkspace.tsx
@@ -67,23 +67,14 @@ export function CipherWorkspace() {
     setTransformError(undefined);
   };
 
-  const runEncode = () => {
+  const runTransform = (direction: "encode" | "decode") => {
     if (!selectedDefinition) return;
     setTransformError(undefined);
     try {
-      const out = selectedDefinition.encode(inputText, parsedParams);
-      setOutputText(out);
-    } catch (e) {
-      setOutputText("");
-      setTransformError(formatCipherError(e));
-    }
-  };
-
-  const runDecode = () => {
-    if (!selectedDefinition) return;
-    setTransformError(undefined);
-    try {
-      const out = selectedDefinition.decode(inputText, parsedParams);
+      const out =
+        direction === "encode"
+          ? selectedDefinition.encode(inputText, parsedParams)
+          : selectedDefinition.decode(inputText, parsedParams);
       setOutputText(out);
     } catch (e) {
       setOutputText("");
@@ -170,7 +161,7 @@ export function CipherWorkspace() {
       <div className="mt-4 flex flex-col gap-3 sm:flex-row">
         <button
           type="button"
-          onClick={runEncode}
+          onClick={() => runTransform("encode")}
           disabled={isActionDisabled}
           className="inline-flex w-full items-center justify-center rounded-xl bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300 sm:w-auto"
         >
@@ -178,7 +169,7 @@ export function CipherWorkspace() {
         </button>
         <button
           type="button"
-          onClick={runDecode}
+          onClick={() => runTransform("decode")}
           disabled={isActionDisabled}
           className="inline-flex w-full items-center justify-center rounded-xl border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-900 transition hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 sm:w-auto"
         >

--- a/lib/ciphers/index.ts
+++ b/lib/ciphers/index.ts
@@ -3,4 +3,4 @@ export { caesarCipher, parseCaesarParams, type CaesarParams } from "./caesar";
 export { identityCipher } from "./identity";
 export { morseCipher, decodeMorse, encodeMorse } from "./morse";
 export { vigenereCipher, parseVigenereParams, type VigenereParams } from "./vigenere";
-export { cipherRegistry, getAllCiphers, getCipherById } from "./registry";
+export { cipherRegistry, getAllCiphers, getCiphersForSelector, getCipherById } from "./registry";

--- a/lib/ciphers/morse.test.ts
+++ b/lib/ciphers/morse.test.ts
@@ -52,6 +52,7 @@ describe("morseCipher", () => {
     } catch (err: unknown) {
       const e = err as CipherValidationError;
       expect(e.code).toBe("MALFORMED_INPUT_DATA");
+      expect(e.detail).toBe("..-.-");
     }
   });
 });

--- a/lib/ciphers/morse.ts
+++ b/lib/ciphers/morse.ts
@@ -191,6 +191,7 @@ export function decodeMorse(cipherText: string): string {
       throw new CipherValidationError('Malformed morse token in input.', {
         code: "MALFORMED_INPUT_DATA",
         field: "*",
+        detail: token,
       });
     }
 

--- a/lib/ciphers/registry.test.ts
+++ b/lib/ciphers/registry.test.ts
@@ -1,4 +1,4 @@
-import { cipherRegistry, getAllCiphers, getCipherById } from "./registry";
+import { cipherRegistry, getAllCiphers, getCipherById, getCiphersForSelector } from "./registry";
 
 describe("cipherRegistry", () => {
   it("lista todas as cifras do MVP", () => {
@@ -15,6 +15,14 @@ describe("cipherRegistry", () => {
     expect(getCipherById("identity")?.id).toBe("identity");
     expect(getCipherById("vigenere")?.id).toBe("vigenere");
     expect(getCipherById("missing")).toBeUndefined();
+  });
+
+  it("getCiphersForSelector exclui cifras só para testes", () => {
+    const ids = getCiphersForSelector()
+      .map((c) => c.id)
+      .sort();
+    expect(ids).toEqual(["atbash", "caesar", "morse", "vigenere"]);
+    expect(getAllCiphers().map((c) => c.id)).toContain("identity");
   });
 
   it("ids são únicos", () => {

--- a/lib/ciphers/registry.ts
+++ b/lib/ciphers/registry.ts
@@ -40,6 +40,9 @@ export const cipherRegistry = defineCipherRegistry(
   vigenereCipher,
 );
 
+/** Ids de cifras só para testes/registry; não aparecem no seletor da UI. */
+const SELECTOR_EXCLUDED_IDS = new Set<string>(["identity"]);
+
 const cipherById: ReadonlyMap<string, CipherDefinition<unknown>> = (() => {
   const map = new Map<string, CipherDefinition<unknown>>();
   for (const def of cipherRegistry) {
@@ -53,6 +56,11 @@ const cipherById: ReadonlyMap<string, CipherDefinition<unknown>> = (() => {
 
 export function getAllCiphers(): readonly CipherDefinition<unknown>[] {
   return cipherRegistry as unknown as readonly CipherDefinition<unknown>[];
+}
+
+/** Lista para o seletor da app (exclui helpers como Identity). */
+export function getCiphersForSelector(): readonly CipherDefinition<unknown>[] {
+  return getAllCiphers().filter((c) => !SELECTOR_EXCLUDED_IDS.has(c.id));
 }
 
 export function getCipherById(id: string): CipherDefinition<unknown> | undefined {

--- a/lib/formatCipherError.test.ts
+++ b/lib/formatCipherError.test.ts
@@ -1,0 +1,48 @@
+import { CipherValidationError } from "@/types/cipher";
+import { formatCipherError } from "./formatCipherError";
+
+describe("formatCipherError", () => {
+  it("retorna mensagem genérica para erro que não é CipherValidationError", () => {
+    expect(formatCipherError(new Error("boom"))).toMatch(/Não foi possível concluir/);
+    expect(formatCipherError("x")).toMatch(/Não foi possível concluir/);
+    expect(formatCipherError(null)).toMatch(/Não foi possível concluir/);
+  });
+
+  it("mapeia códigos conhecidos para português", () => {
+    expect(
+      formatCipherError(
+        new CipherValidationError("x", { code: "PARAM_MISSING", field: "shift" }),
+      ),
+    ).toMatch(/obrigatórios/);
+
+    expect(
+      formatCipherError(
+        new CipherValidationError("x", { code: "PARAM_EMPTY", field: "key" }),
+      ),
+    ).toMatch(/vazio/);
+
+    expect(
+      formatCipherError(
+        new CipherValidationError("x", { code: "PARAM_FORMAT", field: "key" }),
+      ),
+    ).toMatch(/A a Z/);
+  });
+
+  it("inclui detail em MALFORMED_INPUT_DATA", () => {
+    const msg = formatCipherError(
+      new CipherValidationError("Malformed", {
+        code: "MALFORMED_INPUT_DATA",
+        field: "*",
+        detail: "..-.-",
+      }),
+    );
+    expect(msg).toContain("Trecho problemático");
+    expect(msg).toContain("..-.-");
+  });
+
+  it("usa fallback para código desconhecido", () => {
+    expect(
+      formatCipherError(new CipherValidationError("msg", { code: "UNKNOWN_XYZ" })),
+    ).toMatch(/validar/);
+  });
+});

--- a/lib/formatCipherError.ts
+++ b/lib/formatCipherError.ts
@@ -1,0 +1,32 @@
+import { isCipherValidationError } from "@/types/cipher";
+
+const CODE_MESSAGES: Readonly<Record<string, string>> = {
+  PARAMS_OBJECT: "Os parâmetros precisam ser um conjunto simples de campos.",
+  PARAM_MISSING: "Preencha todos os campos obrigatórios.",
+  PARAM_TYPE: "Um dos campos está em um formato que não reconhecemos.",
+  PARAM_INTEGER: "Use um número inteiro para o deslocamento.",
+  PARAM_EMPTY: "Este campo não pode ficar vazio.",
+  PARAM_FORMAT: "Use apenas letras de A a Z, sem números nem símbolos.",
+  MALFORMED_INPUT_DATA: "Uma parte do texto não pôde ser interpretada.",
+  CIPHER_VALIDATION: "Verifique os dados e tente de novo.",
+};
+
+const GENERIC =
+  "Não foi possível concluir a operação. Confira a entrada e tente novamente.";
+
+/**
+ * Converte erros da camada de cifras em mensagem curta para o utilizador (PT).
+ */
+export function formatCipherError(err: unknown): string {
+  if (!isCipherValidationError(err)) {
+    return GENERIC;
+  }
+
+  const base = CODE_MESSAGES[err.code] ?? "Não foi possível validar os dados informados.";
+
+  if (err.code === "MALFORMED_INPUT_DATA" && err.detail !== undefined && err.detail.length > 0) {
+    return `${base} Trecho problemático: «${err.detail}».`;
+  }
+
+  return base;
+}

--- a/lib/formatCipherError.ts
+++ b/lib/formatCipherError.ts
@@ -1,6 +1,21 @@
 import { isCipherValidationError } from "@/types/cipher";
 
-const CODE_MESSAGES: Readonly<Record<string, string>> = {
+/**
+ * Códigos `error.code` emitidos por {@link CipherValidationError} na camada de cifras.
+ * Ao adicionar um novo `code:` em `lib/ciphers/*`, incluir o literal aqui e a entrada em {@link CODE_MESSAGES}.
+ */
+type CipherValidationMessageCode =
+  | "CIPHER_VALIDATION"
+  | "PARAMS_OBJECT"
+  | "PARAM_MISSING"
+  | "PARAM_TYPE"
+  | "PARAM_INTEGER"
+  | "PARAM_EMPTY"
+  | "PARAM_FORMAT"
+  | "MALFORMED_INPUT_DATA";
+
+const CODE_MESSAGES = {
+  CIPHER_VALIDATION: "Verifique os dados e tente de novo.",
   PARAMS_OBJECT: "Os parâmetros precisam ser um conjunto simples de campos.",
   PARAM_MISSING: "Preencha todos os campos obrigatórios.",
   PARAM_TYPE: "Um dos campos está em um formato que não reconhecemos.",
@@ -8,11 +23,19 @@ const CODE_MESSAGES: Readonly<Record<string, string>> = {
   PARAM_EMPTY: "Este campo não pode ficar vazio.",
   PARAM_FORMAT: "Use apenas letras de A a Z, sem números nem símbolos.",
   MALFORMED_INPUT_DATA: "Uma parte do texto não pôde ser interpretada.",
-  CIPHER_VALIDATION: "Verifique os dados e tente de novo.",
-};
+} as const satisfies Record<CipherValidationMessageCode, string>;
 
 const GENERIC =
   "Não foi possível concluir a operação. Confira a entrada e tente novamente.";
+
+const UNKNOWN_CODE_FALLBACK =
+  "Não foi possível validar os dados informados.";
+
+function isCipherValidationMessageCode(
+  code: string,
+): code is CipherValidationMessageCode {
+  return Object.prototype.hasOwnProperty.call(CODE_MESSAGES, code);
+}
 
 /**
  * Converte erros da camada de cifras em mensagem curta para o utilizador (PT).
@@ -22,7 +45,9 @@ export function formatCipherError(err: unknown): string {
     return GENERIC;
   }
 
-  const base = CODE_MESSAGES[err.code] ?? "Não foi possível validar os dados informados.";
+  const base = isCipherValidationMessageCode(err.code)
+    ? CODE_MESSAGES[err.code]
+    : UNKNOWN_CODE_FALLBACK;
 
   if (err.code === "MALFORMED_INPUT_DATA" && err.detail !== undefined && err.detail.length > 0) {
     return `${base} Trecho problemático: «${err.detail}».`;

--- a/lib/tryParseCipherParams.test.ts
+++ b/lib/tryParseCipherParams.test.ts
@@ -1,0 +1,35 @@
+import { tryParseCipherParams } from "@/lib/tryParseCipherParams";
+import type { CipherDefinition } from "@/types/cipher";
+
+describe("tryParseCipherParams", () => {
+  it("sem parseParams devolve params undefined", () => {
+    const def = {
+      id: "x",
+      name: "X",
+      paramFields: [],
+      encode: (t: string) => t,
+      decode: (t: string) => t,
+    } as const satisfies CipherDefinition<unknown>;
+
+    expect(tryParseCipherParams(def, {})).toEqual({ ok: true, params: undefined });
+  });
+
+  it("não relança se parseParams lançar erro genérico", () => {
+    const def: CipherDefinition<unknown> = {
+      id: "bad",
+      name: "Bad",
+      paramFields: [],
+      encode: (t) => t,
+      decode: (t) => t,
+      parseParams: () => {
+        throw new TypeError("internal");
+      },
+    };
+
+    const out = tryParseCipherParams(def, {});
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.errors["*"]).toMatch(/Não foi possível concluir/);
+    }
+  });
+});

--- a/lib/tryParseCipherParams.test.ts
+++ b/lib/tryParseCipherParams.test.ts
@@ -32,4 +32,22 @@ describe("tryParseCipherParams", () => {
       expect(out.errors["*"]).toMatch(/Não foi possível concluir/);
     }
   });
+
+  it("trata { ok: false, error } inválido como falha (não como params)", () => {
+    const def: CipherDefinition<unknown> = {
+      id: "bad-result",
+      name: "Bad result",
+      paramFields: [],
+      encode: (t) => t,
+      decode: (t) => t,
+      parseParams: () =>
+        ({ ok: false, error: new Error("not a CipherValidationError") }) as never,
+    };
+
+    const out = tryParseCipherParams(def, {});
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.errors["*"]).toMatch(/Não foi possível concluir/);
+    }
+  });
 });

--- a/lib/tryParseCipherParams.ts
+++ b/lib/tryParseCipherParams.ts
@@ -1,0 +1,40 @@
+import { formatCipherError } from "@/lib/formatCipherError";
+import {
+  isCipherParamsParseResult,
+  isCipherValidationError,
+  type CipherDefinition,
+} from "@/types/cipher";
+
+export type TryParseCipherParamsResult =
+  | { readonly ok: true; readonly params: unknown }
+  | { readonly ok: false; readonly errors: Record<string, string> };
+
+export function tryParseCipherParams(
+  definition: CipherDefinition<unknown> | undefined,
+  raw: Record<string, unknown>,
+): TryParseCipherParamsResult {
+  if (!definition?.parseParams) {
+    return { ok: true, params: undefined };
+  }
+
+  const format = (e: unknown) => formatCipherError(e);
+
+  try {
+    const out = definition.parseParams(raw);
+    if (isCipherParamsParseResult(out)) {
+      if (!out.ok) {
+        const e = out.error;
+        const field = e.field ?? "*";
+        return { ok: false, errors: { [field]: format(e) } };
+      }
+      return { ok: true, params: out.value };
+    }
+    return { ok: true, params: out };
+  } catch (e) {
+    if (isCipherValidationError(e)) {
+      const field = e.field ?? "*";
+      return { ok: false, errors: { [field]: format(e) } };
+    }
+    return { ok: false, errors: { "*": format(e) } };
+  }
+}

--- a/lib/tryParseCipherParams.ts
+++ b/lib/tryParseCipherParams.ts
@@ -29,6 +29,13 @@ export function tryParseCipherParams(
       }
       return { ok: true, params: out.value };
     }
+    // `ok: false` sem `error` tipado como CipherValidationError falha em
+    // `isCipherParamsParseResult`, mas ainda deve ser tratado como falha.
+    if (out !== null && typeof out === "object" && Reflect.get(out, "ok") === false) {
+      const err = Reflect.get(out, "error");
+      const field = isCipherValidationError(err) ? (err.field ?? "*") : "*";
+      return { ok: false, errors: { [field]: format(err) } };
+    }
     return { ok: true, params: out };
   } catch (e) {
     if (isCipherValidationError(e)) {

--- a/types/cipher.test.ts
+++ b/types/cipher.test.ts
@@ -4,14 +4,16 @@ import {
 } from "./cipher";
 
 describe("CipherValidationError", () => {
-  it("expõe code e field opcional", () => {
+  it("expõe code, field e detail opcionais", () => {
     const err = new CipherValidationError("bad", {
       code: "TEST",
       field: "shift",
+      detail: "x",
     });
     expect(err.message).toBe("bad");
     expect(err.code).toBe("TEST");
     expect(err.field).toBe("shift");
+    expect(err.detail).toBe("x");
     expect(err.name).toBe("CipherValidationError");
   });
 

--- a/types/cipher.ts
+++ b/types/cipher.ts
@@ -81,6 +81,8 @@ export type CipherValidationErrorOptions = {
   readonly code?: string;
   readonly field?: string;
   readonly cause?: unknown;
+  /** Contexto extra para a UI (ex.: token Morse inválido). */
+  readonly detail?: string;
 };
 
 /**
@@ -90,12 +92,14 @@ export type CipherValidationErrorOptions = {
 export class CipherValidationError extends Error {
   readonly code: string;
   readonly field?: string;
+  readonly detail?: string;
 
   constructor(message: string, options?: CipherValidationErrorOptions) {
     super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
     this.name = "CipherValidationError";
     this.code = options?.code ?? "CIPHER_VALIDATION";
     this.field = options?.field;
+    this.detail = options?.detail;
   }
 }
 

--- a/types/cipher.ts
+++ b/types/cipher.ts
@@ -115,6 +115,9 @@ export type CipherParamsParseResult<P> =
 /**
  * Estreita o retorno de `parseParams` para {@link CipherParamsParseResult}
  * sem `as`: discrimina por `ok` e valida `value` / instância de {@link CipherValidationError}.
+ * Se `ok === false` mas `error` não for {@link CipherValidationError}, devolve `false`
+ * (valor inválido para o contrato); o agregador do resultado cru deve tratar esse caso
+ * explicitamente.
  */
 export function isCipherParamsParseResult<P = unknown>(
   value: unknown,


### PR DESCRIPTION
# Pull request: validação de parâmetros, erros na UI e cifras reais (CV-014)

## Resumo

Esta PR implementa o fluxo de **validação e mensagens de erro** acordados na issue **CV-014** (estados vazios, parâmetros inválidos, Morse inválido), liga a workspace às funções **reais** `encode` / `decode` do registry e **oculta a cifra Identity** do seletor (mantendo-a no registry para testes).

## Motivação

- Mensagens **claras, em português** e consistentes entre erros de **parâmetros** e erros de **transformação** (texto de entrada).
- Evitar **exceções não tratadas** na UI quando `parseParams` falha de forma inesperada.
- Permitir testar erros de Morse e outras cifras com o mesmo fluxo que o utilizador vê na app.

## Alterações principais

### UI (`CipherWorkspace`)

- Substituição dos mocks por chamadas a `selectedDefinition.encode` / `decode` com **parâmetros já parseados**.
- Estado **`transformError`**: em caso de falha na transformação, o resultado é **limpo** e mostra-se uma região com `role="alert"` e `aria-live="assertive"`.
- Limpeza do erro de transformação ao mudar **cifra**, **parâmetros** ou **texto de entrada**; limpeza após operação bem-sucedida.
- O seletor de cifras passa a usar **`getCiphersForSelector()`** em vez de `getAllCiphers()`, de modo a **não listar Identity** (cifra auxiliar para testes).

### Biblioteca

- **`lib/formatCipherError.ts`**: converte `CipherValidationError` (por `code`) e erros genéricos em texto **curto em PT**; para Morse inválido, acrescenta o **trecho problemático** quando existe `detail`.
- **`lib/tryParseCipherParams.ts`**: devolve `{ ok: true, params }` ou `{ ok: false, errors }`; mensagens via `formatCipherError`; **não relança** exceções desconhecidas de `parseParams` (mapeiam para `errors["*"]`).
- **`types/cipher.ts`**: `CipherValidationErrorOptions` / `CipherValidationError` com campo opcional **`detail`** (ex.: token Morse inválido).
- **`lib/ciphers/morse.ts`**: em token Morse-like inválido, o erro inclui `detail: token`.

### Testes

- Testes unitários para `formatCipherError` e `tryParseCipherParams`.
- **`CipherWorkspace.test.tsx`**: comportamento real (ex.: Atbash como primeira cifra visível), Morse inválido com alerta em PT, remoção do alerta ao trocar de cifra, lista do seletor alinhada a `getCiphersForSelector`.
- **`registry.test.ts`**: garante que `getCiphersForSelector` exclui `identity` e que `getAllCiphers` ainda a inclui.
- Ajustes em `morse.test.ts` e `types/cipher.test.ts`.

## Ficheiros tocados (visão por área)

| Área | Ficheiros |
|------|-----------|
| UI | `components/CipherWorkspace.tsx`, `components/CipherWorkspace.test.tsx` |
| Erros / parse | `lib/formatCipherError.ts`, `lib/formatCipherError.test.ts`, `lib/tryParseCipherParams.ts`, `lib/tryParseCipherParams.test.ts` |
| Registry / Morse | `lib/ciphers/registry.ts`, `lib/ciphers/registry.test.ts`, `lib/ciphers/index.ts`, `lib/ciphers/morse.ts`, `lib/ciphers/morse.test.ts` |
| Tipos | `types/cipher.ts`, `types/cipher.test.ts` |

## Checklist manual (QA)

- [ ] Entrada vazia ou só espaços: botões desativados, sem erro de transformação.
- [ ] César sem deslocamento com texto: botões desativados.
- [ ] César com deslocamento não inteiro ou inválido: mensagem no campo (PT).
- [ ] Vigenère com chave vazia ou com dígitos/símbolos: mensagem no campo (PT).
- [ ] Morse: decodificar `..-.-` mostra alerta com trecho problemático (PT).
- [ ] Após erro de transformação, trocar de cifra ou editar entrada/params: alerta desaparece.
- [ ] Happy path: Atbash, César com shift válido, Morse (ex.: SOS).
- [ ] Seletor **não** mostra “Identity”; restantes cifras listadas corretamente.

## Como rever

1. `npm test` e `npm run typecheck` (ou `npm run lint`, conforme o projeto).
2. `npm run dev`, percorrer o checklist acima e confirmar leitores de ecrã / `role="alert"` onde aplicável.

## Referências

- Issue / planeamento: **CV-014** (estados vazios, validação e mensagens).
- Complemento de UX: **Identity** apenas fora do seletor; `getCipherById("identity")` e testes de registry inalterados quanto à existência da definição.
